### PR TITLE
parse all installations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.venv/
+__pycache__/

--- a/appHelper.py
+++ b/appHelper.py
@@ -52,13 +52,13 @@ def get_app():
     cert = read_pem()
     auth = Auth.AppAuth(os.environ["APP_ID"], str(cert))
     gi = GithubIntegration(auth = auth)
-    return gi
+    return {"integration": gi, "app": gi.get_app(), "inst": gi.get_installations()}
 
 def get_slug_id():
     ghapp = get_app()
-    installation = ghapp.get_installations()[0]
+    installation = ghapp["inst"][0]
     gh = installation.get_github_for_installation()
-    app = ghapp.get_app()
+    app = ghapp["app"]
     app_usr = gh.get_user(app.slug+"[bot]")
     email = f'{app_usr.id}+{app_usr.login}@users.noreply.github.com'
     write_string("slug", app.slug)
@@ -68,14 +68,16 @@ def get_slug_id():
 
 def list_repositories():
     ghapp = get_app()
-    installation = ghapp.get_installations()[0]
-    # get the full names for the repositories
-    repos = [{"owner":x.owner.login, "name":x.name} for x in installation.get_repos()]
+    repos = []
+    for installation in ghapp["inst"]:
+        # get the full names for the repositories
+        repos += [{"owner":x.owner.login, "name":x.name} for x in installation.get_repos()]
+
     write_json("repos", repos)
 
 def get_token():
     ghapp = get_app()
-    installation = ghapp.get_installations()[0]
+    installation = ghapp["inst"][0]
     token = ghapp.get_access_token(installation.id)
     write_string("token", token.token)
 

--- a/appHelper.py
+++ b/appHelper.py
@@ -47,7 +47,7 @@ def write_json(key, value):
             f.write(f'{key}<<{rid}\n{json.dumps(value)}\n{rid}\n')
             f.close()
 
-def get_installation():
+def get_app():
     # Auth dance
     cert = read_pem()
     auth = Auth.AppAuth(os.environ["APP_ID"], str(cert))
@@ -55,7 +55,7 @@ def get_installation():
     return gi
 
 def get_slug_id():
-    ghapp = get_installation()
+    ghapp = get_app()
     installation = ghapp.get_installations()[0]
     gh = installation.get_github_for_installation()
     app = ghapp.get_app()
@@ -67,14 +67,14 @@ def get_slug_id():
 
 
 def list_repositories():
-    ghapp = get_installation()
+    ghapp = get_app()
     installation = ghapp.get_installations()[0]
     # get the full names for the repositories
     repos = [{"owner":x.owner.login, "name":x.name} for x in installation.get_repos()]
     write_json("repos", repos)
 
 def get_token():
-    ghapp = get_installation()
+    ghapp = get_app()
     installation = ghapp.get_installations()[0]
     token = ghapp.get_access_token(installation.id)
     write_string("token", token.token)


### PR DESCRIPTION
The `list_repositories()` function was misbehaving because I had foolishly told it to pluck only the first installation from the list.

I've updated the function to first loop through the installations and then append to the list.

This will fix #1
