### PR TITLE
Update workflows to be fully re-useable

### DIFF
--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -73,7 +73,7 @@ jobs:
         name: "Fetch deployment scripts"
         uses: actions/checkout@v4
         with:
-          path: ${{ github.temp }}/scripts
+          path: ${{ runner.temp }}/scripts
           repository: hubverse-org/hub-dashboard-control-room
           persist-credentials: false
           sparse-checkout: |
@@ -102,7 +102,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.token.outputs.token || secrets.key }}
         run: | 
-          bash -x "${{ github.temp }}/scripts/check-branch.sh" \
+          bash -x "${{ runner.temp }}/scripts/check-branch.sh" \
             "ptc/data" \
             "${{ steps.id.outputs.repo }}" \
             "${{ inputs.slug }}" \

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -89,12 +89,12 @@ jobs:
             exit 1
           fi
       - id: check-branch
-        name: "check for ptc/data branch and create if needed"
+        name: "check for ptc/data branch"
         env:
           GH_TOKEN: ${{ steps.token.outputs.token || secrets.key }}
         run: | 
           exists=$(gh api -X GET "repos/${{ steps.id.outputs.repo }}/branches" --jq '.[].name | select(. == "ptc/data")')
-          if [[ "$exists" != "ptc/data" ]]; then
+          if [[ "$exists" = "ptc/data" ]]; then
             fetch=true
           else
             fetch=false

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -62,7 +62,7 @@ jobs:
           pip install --upgrade pip
           pip install git+https://github.com/hubverse-org/hub-dashboard-predtimechart
       - uses: actions/create-github-app-token@v1
-        if: ${{ steps.is-bot.outputs.bot == true }}
+        if: ${{ steps.is-bot.outputs.bot }}
         id: token
         with:
           app-id: ${{ secrets.id }}
@@ -190,7 +190,7 @@ jobs:
           echo "repo=$owner/$name" >> $GITHUB_OUTPUT
           echo "file=$owner-$name-data" >> $GITHUB_OUTPUT
       - uses: actions/create-github-app-token@v1
-        if: ${{ steps.is-bot.outputs.bot == true }}
+        if: ${{ steps.is-bot.outputs.bot }}
         id: token
         with:
           app-id: ${{ secrets.id }}

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -62,7 +62,7 @@ jobs:
           pip install --upgrade pip
           pip install git+https://github.com/hubverse-org/hub-dashboard-predtimechart
       - uses: actions/create-github-app-token@v1
-        if: ${{ steps.is-bot.outputs.bot }}
+        if: ${{ fromJSON(steps.is-bot.outputs.bot) }}
         id: token
         with:
           app-id: ${{ secrets.id }}

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -101,7 +101,7 @@ jobs:
           fi
           echo "fetch=$fetch" >> "$GITHUB_OUTPUT"
       - id: checkout-data
-        if: ${{ steps.check-branch.outputs.fetch != 'false' }}
+        if: ${{ fromJSON(steps.check-branch.outputs.fetch) }}
         name: "Checkout ptc/data branch"
         uses: actions/checkout@v4
         with:
@@ -191,7 +191,7 @@ jobs:
           echo "repo=$owner/$name" >> $GITHUB_OUTPUT
           echo "file=$owner-$name-data" >> $GITHUB_OUTPUT
       - uses: actions/create-github-app-token@v1
-        if: ${{ steps.is-bot.outputs.bot }}
+        if: ${{ fromJSON(steps.is-bot.outputs.bot) }}
         id: token
         with:
           app-id: ${{ secrets.id }}

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -69,6 +69,14 @@ jobs:
           private-key: ${{ secrets.key }}
           owner: ${{ matrix.site.owner }}
           repositories: ${{ matrix.site.name }}
+      - id: checkout-this-here-repo-scripts
+        name: "Fetch deployment scripts"
+        uses: actions/checkout@v4
+        with:
+          repository: hubverse-org/hub-dashboard-control-room
+          persist-credentials: false
+          sparse-checkout: |
+            scripts
       - id: checkout-config
         name: "Fetch config files"
         uses: actions/checkout@v4
@@ -88,14 +96,6 @@ jobs:
             echo "::error title=Missing config (${{ steps.id.outputs.repo }})::No predtimechart-config.yml file found. Exiting."
             exit 1
           fi
-      - id: checkout-this-here-repo-scripts
-        name: "Fetch deployment scripts"
-        uses: actions/checkout@v4
-        with:
-          repository: hubverse-org/hub-dashboard-control-room
-          persist-credentials: false
-          sparse-checkout: |
-            scripts
       - id: check-branch
         name: "check for ptc/data branch and create if needed"
         env:

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -62,7 +62,7 @@ jobs:
           pip install --upgrade pip
           pip install git+https://github.com/hubverse-org/hub-dashboard-predtimechart
       - uses: actions/create-github-app-token@v1
-        if: ${{ steps.is-bot.outputs.bot }}
+        if: ${{ toJSON(steps.is-bot.outputs.bot) }}
         id: token
         with:
           app-id: ${{ secrets.id }}
@@ -101,7 +101,7 @@ jobs:
           fi
           echo "fetch=$fetch" >> "$GITHUB_OUTPUT"
       - id: checkout-data
-        if: ${{ steps.check-branch.outputs.fetch != 'false' }}
+        if: ${{ toJSON(steps.check-branch.outputs.fetch) }}
         name: "Checkout ptc/data branch"
         uses: actions/checkout@v4
         with:
@@ -191,7 +191,7 @@ jobs:
           echo "repo=$owner/$name" >> $GITHUB_OUTPUT
           echo "file=$owner-$name-data" >> $GITHUB_OUTPUT
       - uses: actions/create-github-app-token@v1
-        if: ${{ steps.is-bot.outputs.bot }}
+        if: ${{ toJSON(steps.is-bot.outputs.bot) }}
         id: token
         with:
           app-id: ${{ secrets.id }}

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -26,8 +26,8 @@ jobs:
     name: "Generate Data"
     runs-on: ubuntu-latest
     continue-on-error: true
-    strategy: 
-      matrix: 
+    strategy:
+      matrix:
         site: ${{ fromJSON(inputs.repos) }}
     steps:
       - id: is-bot
@@ -93,14 +93,15 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.token.outputs.token || secrets.key }}
         run: | 
-          curl "https://raw.githubusercontent.com/hubverse-org/hub-dashboard-control-room/refs/heads/znk/no-token/scripts/check-branch.sh" |
-          bash -x /dev/stdin \
-            "ptc/data" \
-            "${{ steps.id.outputs.repo }}" \
-            "${{ inputs.slug }}" \
-            "${{ inputs.email }}" \
-            "${{ steps.token.outputs.token || secrets.key }}"
+          exists=$(gh api -X GET "repos/${{ steps.id.outputs.repo }}/branches" --jq '.[].name | select(. == "ptc/data")')
+          if [[ "$exists" != "ptc/data" ]]; then
+            fetch=true
+          else
+            fetch=false
+          fi
+          echo "fetch=$fetch" >> "$GITHUB_OUTPUT"
       - id: checkout-data
+        if: ${{ steps.check-branch.outputs.fetch }}
         name: "Checkout ptc/data branch"
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -73,7 +73,7 @@ jobs:
         name: "Fetch deployment scripts"
         uses: actions/checkout@v4
         with:
-          path: ${{ runner.temp }}/scripts
+          path: scripts
           repository: hubverse-org/hub-dashboard-control-room
           persist-credentials: false
           sparse-checkout: |
@@ -102,7 +102,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.token.outputs.token || secrets.key }}
         run: | 
-          bash -x "${{ runner.temp }}/scripts/check-branch.sh" \
+          bash -x "${{ github.workspace }}/scripts/check-branch.sh" \
             "ptc/data" \
             "${{ steps.id.outputs.repo }}" \
             "${{ inputs.slug }}" \

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -69,15 +69,6 @@ jobs:
           private-key: ${{ secrets.key }}
           owner: ${{ matrix.site.owner }}
           repositories: ${{ matrix.site.name }}
-      - id: checkout-this-here-repo-scripts
-        name: "Fetch deployment scripts"
-        uses: actions/checkout@v4
-        with:
-          path: scripts
-          repository: hubverse-org/hub-dashboard-control-room
-          persist-credentials: false
-          sparse-checkout: |
-            scripts
       - id: checkout-config
         name: "Fetch config files"
         uses: actions/checkout@v4
@@ -102,7 +93,8 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.token.outputs.token || secrets.key }}
         run: | 
-          bash -x "${{ github.workspace }}/scripts/check-branch.sh" \
+          curl "https://raw.githubusercontent.com/hubverse-org/hub-dashboard-control-room/refs/heads/znk/no-token/scripts/check-branch.sh" |
+          bash -x /dev/stdin \
             "ptc/data" \
             "${{ steps.id.outputs.repo }}" \
             "${{ inputs.slug }}" \

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -88,6 +88,17 @@ jobs:
             echo "::error title=Missing config (${{ steps.id.outputs.repo }})::No predtimechart-config.yml file found. Exiting."
             exit 1
           fi
+      - id: check-branch
+        name: "check for ptc/data branch and create if needed"
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token || secrets.key }}
+        run: | 
+          bash -x "${{ github.workspace }}/scripts/check-branch.sh" \
+            "ptc/data" \
+            "${{ steps.id.outputs.repo }}" \
+            "${{ inputs.slug }}" \
+            "${{ inputs.email }}" \
+            "${{ steps.token.outputs.token || secrets.key }}"
       - id: checkout-data
         name: "Checkout ptc/data branch"
         uses: actions/checkout@v4

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -101,7 +101,7 @@ jobs:
           fi
           echo "fetch=$fetch" >> "$GITHUB_OUTPUT"
       - id: checkout-data
-        if: ${{ steps.check-branch.outputs.fetch }}
+        if: ${{ steps.check-branch.outputs.fetch != 'false' }}
         name: "Checkout ptc/data branch"
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -33,7 +33,7 @@ jobs:
       - id: is-bot
         name: "Check if we are running a bot"
         run: |
-          if [[ "${{ secrets.id }}"=="none" ]]; then
+          if [[ "${{ secrets.id }}" = "none" ]]; then
             bot=false
           else
             bot=true
@@ -168,7 +168,7 @@ jobs:
       - id: is-bot
         name: "Check if we are running a bot"
         run: |
-          if [[ "${{ secrets.id }}"=="none" ]]; then
+          if [[ "${{ secrets.id }}" = "none" ]]; then
             bot=false
           else
             bot=true

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -73,6 +73,7 @@ jobs:
         name: "Fetch deployment scripts"
         uses: actions/checkout@v4
         with:
+          path: scripts
           repository: hubverse-org/hub-dashboard-control-room
           persist-credentials: false
           sparse-checkout: |

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -30,6 +30,16 @@ jobs:
       matrix: 
         site: ${{ fromJSON(inputs.repos) }}
     steps:
+      - id: is-bot
+        name: "Check if we are running a bot"
+        run: |
+          if [[ "${{ secrets.id }}"=="none" ]]; then
+            bot=false
+          else
+            bot=true
+          fi
+          echo "bot=$bot" >> "$GITHUB_OUTPUT"
+        shell: bash
       - id: id
         name: "setup run variables"
         run: |
@@ -52,6 +62,7 @@ jobs:
           pip install --upgrade pip
           pip install git+https://github.com/hubverse-org/hub-dashboard-predtimechart
       - uses: actions/create-github-app-token@v1
+        if: ${{ steps.is-bot.outputs.bot == true }}
         id: token
         with:
           app-id: ${{ secrets.id }}
@@ -63,7 +74,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-          token: ${{ steps.token.outputs.token }}
+          token: ${{ steps.token.outputs.token || secrets.key }}
           repository: ${{ steps.id.outputs.repo }}
           sparse-checkout-cone-mode: false
           sparse-checkout: |
@@ -81,7 +92,7 @@ jobs:
         name: "Checkout ptc/data branch"
         uses: actions/checkout@v4
         with:
-          token: ${{ steps.token.outputs.token }}
+          token: ${{ steps.token.outputs.token || secrets.key }}
           persist-credentials: false
           repository: ${{ steps.id.outputs.repo }}
           ref: 'ptc/data'
@@ -142,6 +153,16 @@ jobs:
       matrix: 
         site: ${{ fromJSON(inputs.repos) }}
     steps:
+      - id: is-bot
+        name: "Check if we are running a bot"
+        run: |
+          if [[ "${{ secrets.id }}"=="none" ]]; then
+            bot=false
+          else
+            bot=true
+          fi
+          echo "bot=$bot" >> "$GITHUB_OUTPUT"
+        shell: bash
       - id: checkout-this-here-repo-scripts
         uses: actions/checkout@v4
         with:
@@ -157,6 +178,7 @@ jobs:
           echo "repo=$owner/$name" >> $GITHUB_OUTPUT
           echo "file=$owner-$name-data" >> $GITHUB_OUTPUT
       - uses: actions/create-github-app-token@v1
+        if: ${{ steps.is-bot.outputs.bot == true }}
         id: token
         with:
           app-id: ${{ secrets.id }}
@@ -173,7 +195,7 @@ jobs:
             "${{ steps.id.outputs.repo }}" \
             "${{ inputs.slug }}" \
             "${{ inputs.email }}" \
-            "${{ steps.token.outputs.token }}"
+            "${{ steps.token.outputs.token || secrets.key }}"
       - id: checkout-pages
         uses: actions/checkout@v4
         with:
@@ -181,7 +203,7 @@ jobs:
           repository: ${{ steps.id.outputs.repo }}
           ref: ptc/data
           path: 'data'
-          token: ${{ steps.token.outputs.token }}
+          token: ${{ steps.token.outputs.token || secrets.key }}
       - id: fetch-artifact
         uses: actions/download-artifact@v4
         with:
@@ -195,4 +217,4 @@ jobs:
             "${{ steps.id.outputs.repo }}" \
             "${{ inputs.slug }}" \
             "${{ inputs.email }}" \
-            "${{ steps.token.outputs.token }}"
+            "${{ steps.token.outputs.token || secrets.key }}"

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -62,7 +62,7 @@ jobs:
           pip install --upgrade pip
           pip install git+https://github.com/hubverse-org/hub-dashboard-predtimechart
       - uses: actions/create-github-app-token@v1
-        if: ${{ toJSON(steps.is-bot.outputs.bot) }}
+        if: ${{ steps.is-bot.outputs.bot }}
         id: token
         with:
           app-id: ${{ secrets.id }}
@@ -101,7 +101,7 @@ jobs:
           fi
           echo "fetch=$fetch" >> "$GITHUB_OUTPUT"
       - id: checkout-data
-        if: ${{ toJSON(steps.check-branch.outputs.fetch) }}
+        if: ${{ steps.check-branch.outputs.fetch != 'false' }}
         name: "Checkout ptc/data branch"
         uses: actions/checkout@v4
         with:
@@ -191,7 +191,7 @@ jobs:
           echo "repo=$owner/$name" >> $GITHUB_OUTPUT
           echo "file=$owner-$name-data" >> $GITHUB_OUTPUT
       - uses: actions/create-github-app-token@v1
-        if: ${{ toJSON(steps.is-bot.outputs.bot) }}
+        if: ${{ steps.is-bot.outputs.bot }}
         id: token
         with:
           app-id: ${{ secrets.id }}

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -73,7 +73,7 @@ jobs:
         name: "Fetch deployment scripts"
         uses: actions/checkout@v4
         with:
-          path: scripts
+          path: ${{ github.temp }}/scripts
           repository: hubverse-org/hub-dashboard-control-room
           persist-credentials: false
           sparse-checkout: |
@@ -102,7 +102,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.token.outputs.token || secrets.key }}
         run: | 
-          bash -x "${{ github.workspace }}/scripts/check-branch.sh" \
+          bash -x "${{ github.temp }}/scripts/check-branch.sh" \
             "ptc/data" \
             "${{ steps.id.outputs.repo }}" \
             "${{ inputs.slug }}" \

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -88,6 +88,14 @@ jobs:
             echo "::error title=Missing config (${{ steps.id.outputs.repo }})::No predtimechart-config.yml file found. Exiting."
             exit 1
           fi
+      - id: checkout-this-here-repo-scripts
+        name: "Fetch deployment scripts"
+        uses: actions/checkout@v4
+        with:
+          repository: hubverse-org/hub-dashboard-control-room
+          persist-credentials: false
+          sparse-checkout: |
+            scripts
       - id: check-branch
         name: "check for ptc/data branch and create if needed"
         env:

--- a/.github/workflows/generate-site.yaml
+++ b/.github/workflows/generate-site.yaml
@@ -56,7 +56,7 @@ jobs:
         name: "Fetch ${{ steps.id.outputs.repo }}"
         uses: actions/checkout@v4
         with:
-          token: ${{ steps.token.outputs.token || secrets.token }}
+          token: ${{ steps.token.outputs.token || github.token }}
           persist-credentials: false
           repository: ${{ steps.id.outputs.repo }}
       - id: check-configs
@@ -152,7 +152,7 @@ jobs:
             "${{ steps.id.outputs.repo }}" \
             "${{ inputs.slug }}" \
             "${{ inputs.email }}" \
-            "${{ steps.token.outputs.token || secrets.token }}"
+            "${{ steps.token.outputs.token || github.token }}"
       - id: checkout-pages
         name: "Fetch ${{ steps.id.outputs.repo }}"
         uses: actions/checkout@v4
@@ -161,7 +161,7 @@ jobs:
           repository: ${{ steps.id.outputs.repo }}
           ref: gh-pages
           path: 'pages'
-          token: ${{ steps.token.outputs.token || secrets.token }}
+          token: ${{ steps.token.outputs.token || github.token }}
       - id: fetch-artifact
         name: "Load changes"
         uses: actions/download-artifact@v4
@@ -175,4 +175,4 @@ jobs:
             "${{ steps.id.outputs.repo }}" \
             "${{ inputs.slug }}" \
             "${{ inputs.email }}" \
-            "${{ steps.token.outputs.token || secrets.token }}"
+            "${{ steps.token.outputs.token || github.token }}"

--- a/.github/workflows/generate-site.yaml
+++ b/.github/workflows/generate-site.yaml
@@ -39,6 +39,7 @@ jobs:
       - id: is-bot
         name: "Check if we are running a bot"
         run: |
+          echo "${{ secrets.token }}"
           if [[ -z "${{ secrets.id }}" ]]; then
             bot=false
           else

--- a/.github/workflows/generate-site.yaml
+++ b/.github/workflows/generate-site.yaml
@@ -42,6 +42,7 @@ jobs:
           else
             bot=true
           fi
+          echo "bot is $bot"
           echo "bot=$bot" >> "$GITHUB_OUTPUT"
         shell: bash
       - uses: actions/create-github-app-token@v1

--- a/.github/workflows/generate-site.yaml
+++ b/.github/workflows/generate-site.yaml
@@ -137,7 +137,7 @@ jobs:
       - id: is-bot
         name: "Check if we are running a bot"
         run: |
-          if [[ -z "${{ secrets.id }}" ]]; then
+          if [[ "${{ secrets.id }}" = "none" ]]; then
             bot=false
           else
             bot=true

--- a/.github/workflows/generate-site.yaml
+++ b/.github/workflows/generate-site.yaml
@@ -46,7 +46,7 @@ jobs:
           echo "bot=$bot" >> "$GITHUB_OUTPUT"
         shell: bash
       - uses: actions/create-github-app-token@v1
-        if: ${{ steps.is-bot.outputs.bot == true }}
+        if: ${{ steps.is-bot.outputs.bot }}
         name: "Generate App Token (if no token present)"
         id: token
         with:
@@ -93,7 +93,7 @@ jobs:
           && echo "success=true" >> $GITHUB_OUTPUT \
           || echo "success=false" >> $GITHUB_OUTPUT
       - name: Upload artifact
-        # if: ${{ steps.build-site.outputs.success == true }}
+        # if: ${{ steps.build-site.outputs.success }}
         id: upload
         uses: actions/upload-artifact@v4
         with:
@@ -101,7 +101,7 @@ jobs:
           path: '/site/pages/'
           retention-days: 1
       # - name: signal success
-      #   # if: ${{ steps.build-site.outputs.success == true }}
+      #   # if: ${{ steps.build-site.outputs.success }}
       #   run: |
       #     touch "${{runner.temp}}/${{steps.id.outputs.file}}.success" 
   push-site:
@@ -145,7 +145,7 @@ jobs:
           echo "bot=$bot" >> "$GITHUB_OUTPUT"
         shell: bash
       - uses: actions/create-github-app-token@v1
-        if: ${{ steps.is-bot.outputs.bot == true }}
+        if: ${{ steps.is-bot.outputs.bot }}
         id: token
         with:
           app-id: ${{ secrets.id }}

--- a/.github/workflows/generate-site.yaml
+++ b/.github/workflows/generate-site.yaml
@@ -37,7 +37,7 @@ jobs:
         - ${{ github.workspace }}:/site
     steps:
       - uses: actions/create-github-app-token@v1
-        if: ${{ secrets.id || false }}
+        if: ${{ secrets.id != "" }}
         name: "Generate App Token (if no token present)"
         id: token
         with:
@@ -126,8 +126,8 @@ jobs:
           sparse-checkout: |
             scripts
       - uses: actions/create-github-app-token@v1
+        if: ${{ secrets.id != "" }}
         id: token
-        if: ${{ secrets.id || false }}
         with:
           app-id: ${{ secrets.id }}
           private-key: ${{ secrets.key }}

--- a/.github/workflows/generate-site.yaml
+++ b/.github/workflows/generate-site.yaml
@@ -37,7 +37,7 @@ jobs:
       - id: is-bot
         name: "Check if we are running a bot"
         run: |
-          if [[ "${{ secrets.id }}"=="none" ]]; then
+          if [[ "${{ secrets.id }}" = "none" ]]; then
             bot=false
           else
             bot=true

--- a/.github/workflows/generate-site.yaml
+++ b/.github/workflows/generate-site.yaml
@@ -37,7 +37,7 @@ jobs:
       - id: is-bot
         name: "Check if we are running a bot"
         run: |
-          echo "${{ secrets.token }}"
+          echo "${{ secrets.key }}"
           if [[ "${{ secrets.id }}"=="none" ]]; then
             bot=false
           else

--- a/.github/workflows/generate-site.yaml
+++ b/.github/workflows/generate-site.yaml
@@ -37,7 +37,7 @@ jobs:
         - ${{ github.workspace }}:/site
     steps:
       - uses: actions/create-github-app-token@v1
-        if: ${{ secrets.id }}
+        if: ${{ secrets.id || false }}
         name: "Generate App Token (if no token present)"
         id: token
         with:
@@ -127,6 +127,7 @@ jobs:
             scripts
       - uses: actions/create-github-app-token@v1
         id: token
+        if: ${{ secrets.id || false }}
         with:
           app-id: ${{ secrets.id }}
           private-key: ${{ secrets.key }}

--- a/.github/workflows/generate-site.yaml
+++ b/.github/workflows/generate-site.yaml
@@ -6,16 +6,18 @@ on:
         required: true
         type: string
       slug:
-        required: true
+        required: false
         type: string
       email:
-        required: true
+        required: false
         type: string
     secrets:
       id:
-        required: true
+        required: false
       key:
-        required: true
+        required: false
+      token:
+        required: false
 
 jobs:
   build-site:
@@ -35,6 +37,7 @@ jobs:
         - ${{ github.workspace }}:/site
     steps:
       - uses: actions/create-github-app-token@v1
+        if: ${{ secrets.id }}
         name: "Generate App Token (if no token present)"
         id: token
         with:
@@ -53,7 +56,7 @@ jobs:
         name: "Fetch ${{ steps.id.outputs.repo }}"
         uses: actions/checkout@v4
         with:
-          token: ${{ steps.token.outputs.token }}
+          token: ${{ steps.token.outputs.token || secrets.token }}
           persist-credentials: false
           repository: ${{ steps.id.outputs.repo }}
       - id: check-configs
@@ -139,7 +142,7 @@ jobs:
             "${{ steps.id.outputs.repo }}" \
             "${{ inputs.slug }}" \
             "${{ inputs.email }}" \
-            "${{ steps.token.outputs.token }}"
+            "${{ steps.token.outputs.token || secrets.token }}"
       - id: checkout-pages
         name: "Fetch ${{ steps.id.outputs.repo }}"
         uses: actions/checkout@v4
@@ -148,7 +151,7 @@ jobs:
           repository: ${{ steps.id.outputs.repo }}
           ref: gh-pages
           path: 'pages'
-          token: ${{ steps.token.outputs.token }}
+          token: ${{ steps.token.outputs.token || secrets.token }}
       - id: fetch-artifact
         name: "Load changes"
         uses: actions/download-artifact@v4
@@ -162,4 +165,4 @@ jobs:
             "${{ steps.id.outputs.repo }}" \
             "${{ inputs.slug }}" \
             "${{ inputs.email }}" \
-            "${{ steps.token.outputs.token }}"
+            "${{ steps.token.outputs.token || secrets.token }}"

--- a/.github/workflows/generate-site.yaml
+++ b/.github/workflows/generate-site.yaml
@@ -6,10 +6,10 @@ on:
         required: true
         type: string
       slug:
-        required: false
+        required: true
         type: string
       email:
-        required: false
+        required: true
         type: string
     secrets:
       id:

--- a/.github/workflows/generate-site.yaml
+++ b/.github/workflows/generate-site.yaml
@@ -46,7 +46,7 @@ jobs:
           echo "bot=$bot" >> "$GITHUB_OUTPUT"
         shell: bash
       - uses: actions/create-github-app-token@v1
-        if: ${{ steps.is-bot.outputs.bot }}
+        if: ${{ fromJSON(steps.is-bot.outputs.bot) }}
         name: "Generate App Token (if no token present)"
         id: token
         with:
@@ -93,7 +93,7 @@ jobs:
           && echo "success=true" >> $GITHUB_OUTPUT \
           || echo "success=false" >> $GITHUB_OUTPUT
       - name: Upload artifact
-        # if: ${{ steps.build-site.outputs.success }}
+        # if: ${{ fromJSON(steps.build-site.outputs.success) }}
         id: upload
         uses: actions/upload-artifact@v4
         with:
@@ -101,7 +101,7 @@ jobs:
           path: '/site/pages/'
           retention-days: 1
       # - name: signal success
-      #   # if: ${{ steps.build-site.outputs.success }}
+      #   # if: ${{ fromJSON(steps.build-site.outputs.success) }}
       #   run: |
       #     touch "${{runner.temp}}/${{steps.id.outputs.file}}.success" 
   push-site:
@@ -145,7 +145,7 @@ jobs:
           echo "bot=$bot" >> "$GITHUB_OUTPUT"
         shell: bash
       - uses: actions/create-github-app-token@v1
-        if: ${{ steps.is-bot.outputs.bot }}
+        if: ${{ fromJSON(steps.is-bot.outputs.bot) }}
         id: token
         with:
           app-id: ${{ secrets.id }}

--- a/.github/workflows/generate-site.yaml
+++ b/.github/workflows/generate-site.yaml
@@ -47,7 +47,7 @@ jobs:
           echo "bot=$bot" >> "$GITHUB_OUTPUT"
         shell: bash
       - uses: actions/create-github-app-token@v1
-        if: ${{ steps.is-bot.outputs.bot }}
+        if: ${{ steps.is-bot.outputs.bot == true }}
         name: "Generate App Token (if no token present)"
         id: token
         with:
@@ -146,7 +146,7 @@ jobs:
           echo "bot=$bot" >> "$GITHUB_OUTPUT"
         shell: bash
       - uses: actions/create-github-app-token@v1
-        if: ${{ steps.is-bot.outputs.bot }}
+        if: ${{ steps.is-bot.outputs.bot == true }}
         id: token
         with:
           app-id: ${{ secrets.id }}

--- a/.github/workflows/generate-site.yaml
+++ b/.github/workflows/generate-site.yaml
@@ -36,6 +36,15 @@ jobs:
       volumes:
         - ${{ github.workspace }}:/site
     steps:
+      - id: is-bot
+        name: "Check if we are running a bot"
+        run: |
+          if [[ -z "${{ secrets.id }}" ]]; then
+            bot=true
+          else
+            bot=false
+          fi
+          echo "bot=$bot" >> "$GITHUB_OUTPUT"
       - uses: actions/create-github-app-token@v1
         if: ${{ steps.is-bot.outputs.bot }}
         name: "Generate App Token (if no token present)"

--- a/.github/workflows/generate-site.yaml
+++ b/.github/workflows/generate-site.yaml
@@ -66,7 +66,7 @@ jobs:
         name: "Fetch ${{ steps.id.outputs.repo }}"
         uses: actions/checkout@v4
         with:
-          token: ${{ steps.token.outputs.token || github.token }}
+          token: ${{ steps.token.outputs.token || secrets.token }}
           persist-credentials: false
           repository: ${{ steps.id.outputs.repo }}
       - id: check-configs
@@ -156,14 +156,14 @@ jobs:
       - id: check-branch
         name: "check for gh-pages branch and create if needed"
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.token || github.token }}
         run: | 
           bash -x "${{ github.workspace }}/scripts/check-branch.sh" \
             "gh-pages" \
             "${{ steps.id.outputs.repo }}" \
             "${{ inputs.slug }}" \
             "${{ inputs.email }}" \
-            "${{ steps.token.outputs.token || github.token }}"
+            "${{ steps.token.outputs.token || secrets.token }}"
       - id: checkout-pages
         name: "Fetch ${{ steps.id.outputs.repo }}"
         uses: actions/checkout@v4
@@ -172,7 +172,7 @@ jobs:
           repository: ${{ steps.id.outputs.repo }}
           ref: gh-pages
           path: 'pages'
-          token: ${{ steps.token.outputs.token || github.token }}
+          token: ${{ steps.token.outputs.token || secrets.token }}
       - id: fetch-artifact
         name: "Load changes"
         uses: actions/download-artifact@v4
@@ -186,4 +186,4 @@ jobs:
             "${{ steps.id.outputs.repo }}" \
             "${{ inputs.slug }}" \
             "${{ inputs.email }}" \
-            "${{ steps.token.outputs.token || github.token }}"
+            "${{ steps.token.outputs.token || secrets.token }}"

--- a/.github/workflows/generate-site.yaml
+++ b/.github/workflows/generate-site.yaml
@@ -13,11 +13,9 @@ on:
         type: string
     secrets:
       id:
-        required: false
+        required: true
       key:
-        required: false
-      token:
-        required: false
+        required: true
 
 jobs:
   build-site:
@@ -40,7 +38,7 @@ jobs:
         name: "Check if we are running a bot"
         run: |
           echo "${{ secrets.token }}"
-          if [[ -z "${{ secrets.id }}" ]]; then
+          if [[ "${{ secrets.id }}"=="none" ]]; then
             bot=false
           else
             bot=true
@@ -67,7 +65,7 @@ jobs:
         name: "Fetch ${{ steps.id.outputs.repo }}"
         uses: actions/checkout@v4
         with:
-          token: ${{ steps.token.outputs.token || secrets.token }}
+          token: ${{ steps.token.outputs.token || secrets.key }}
           persist-credentials: false
           repository: ${{ steps.id.outputs.repo }}
       - id: check-configs
@@ -157,14 +155,14 @@ jobs:
       - id: check-branch
         name: "check for gh-pages branch and create if needed"
         env:
-          GH_TOKEN: ${{ secrets.token || github.token }}
+          GH_TOKEN: ${{ secrets.key || github.token }}
         run: | 
           bash -x "${{ github.workspace }}/scripts/check-branch.sh" \
             "gh-pages" \
             "${{ steps.id.outputs.repo }}" \
             "${{ inputs.slug }}" \
             "${{ inputs.email }}" \
-            "${{ steps.token.outputs.token || secrets.token }}"
+            "${{ steps.token.outputs.token || secrets.key }}"
       - id: checkout-pages
         name: "Fetch ${{ steps.id.outputs.repo }}"
         uses: actions/checkout@v4
@@ -173,7 +171,7 @@ jobs:
           repository: ${{ steps.id.outputs.repo }}
           ref: gh-pages
           path: 'pages'
-          token: ${{ steps.token.outputs.token || secrets.token }}
+          token: ${{ steps.token.outputs.token || secrets.key }}
       - id: fetch-artifact
         name: "Load changes"
         uses: actions/download-artifact@v4

--- a/.github/workflows/generate-site.yaml
+++ b/.github/workflows/generate-site.yaml
@@ -40,9 +40,9 @@ jobs:
         name: "Check if we are running a bot"
         run: |
           if [[ -z "${{ secrets.id }}" ]]; then
-            bot=true
-          else
             bot=false
+          else
+            bot=true
           fi
           echo "bot=$bot" >> "$GITHUB_OUTPUT"
         shell: bash
@@ -139,9 +139,9 @@ jobs:
         name: "Check if we are running a bot"
         run: |
           if [[ -z "${{ secrets.id }}" ]]; then
-            bot=true
-          else
             bot=false
+          else
+            bot=true
           fi
           echo "bot=$bot" >> "$GITHUB_OUTPUT"
         shell: bash

--- a/.github/workflows/generate-site.yaml
+++ b/.github/workflows/generate-site.yaml
@@ -184,4 +184,4 @@ jobs:
             "${{ steps.id.outputs.repo }}" \
             "${{ inputs.slug }}" \
             "${{ inputs.email }}" \
-            "${{ steps.token.outputs.token || secrets.token }}"
+            "${{ steps.token.outputs.token || secrets.key }}"

--- a/.github/workflows/generate-site.yaml
+++ b/.github/workflows/generate-site.yaml
@@ -37,7 +37,7 @@ jobs:
         - ${{ github.workspace }}:/site
     steps:
       - uses: actions/create-github-app-token@v1
-        if: ${{ secrets.id != "" }}
+        if: ${{ steps.is-bot.outputs.bot }}
         name: "Generate App Token (if no token present)"
         id: token
         with:
@@ -125,8 +125,17 @@ jobs:
           persist-credentials: false
           sparse-checkout: |
             scripts
+      - id: is-bot
+        name: "Check if we are running a bot"
+        run: |
+          if [[ -z "${{ secrets.id }}" ]]; then
+            bot=true
+          else
+            bot=false
+          fi
+          echo "bot=$bot" >> "$GITHUB_OUTPUT"
       - uses: actions/create-github-app-token@v1
-        if: ${{ secrets.id != "" }}
+        if: ${{ steps.is-bot.outputs.bot }}
         id: token
         with:
           app-id: ${{ secrets.id }}

--- a/.github/workflows/generate-site.yaml
+++ b/.github/workflows/generate-site.yaml
@@ -37,7 +37,6 @@ jobs:
       - id: is-bot
         name: "Check if we are running a bot"
         run: |
-          echo "${{ secrets.key }}"
           if [[ "${{ secrets.id }}"=="none" ]]; then
             bot=false
           else

--- a/.github/workflows/generate-site.yaml
+++ b/.github/workflows/generate-site.yaml
@@ -45,6 +45,7 @@ jobs:
             bot=false
           fi
           echo "bot=$bot" >> "$GITHUB_OUTPUT"
+        shell: bash
       - uses: actions/create-github-app-token@v1
         if: ${{ steps.is-bot.outputs.bot }}
         name: "Generate App Token (if no token present)"
@@ -143,6 +144,7 @@ jobs:
             bot=false
           fi
           echo "bot=$bot" >> "$GITHUB_OUTPUT"
+        shell: bash
       - uses: actions/create-github-app-token@v1
         if: ${{ steps.is-bot.outputs.bot }}
         id: token

--- a/.github/workflows/generate-site.yaml
+++ b/.github/workflows/generate-site.yaml
@@ -154,7 +154,7 @@ jobs:
       - id: check-branch
         name: "check for gh-pages branch and create if needed"
         env:
-          GH_TOKEN: ${{ secrets.key || github.token }}
+          GH_TOKEN: ${{ steps.token.outputs.token || secrets.key }}
         run: | 
           bash -x "${{ github.workspace }}/scripts/check-branch.sh" \
             "gh-pages" \

--- a/.github/workflows/rebuild-data.yaml
+++ b/.github/workflows/rebuild-data.yaml
@@ -22,7 +22,7 @@ jobs:
       repos: '${{ needs.repos.outputs.repos }}'
       slug: '${{ needs.repos.outputs.slug }}'
       email: '${{ needs.repos.outputs.email }}'
-      regenerate: ${{ github.event.client_payload.regenerate }}
+      regenerate: ${{ github.event.client_payload.regenerate || false }}
     secrets:
       id: ${{ vars.APP_ID }}
       key: ${{ secrets.PRIVATE_KEY }}

--- a/.github/workflows/rebuild-data.yaml
+++ b/.github/workflows/rebuild-data.yaml
@@ -22,7 +22,7 @@ jobs:
       repos: '${{ needs.repos.outputs.repos }}'
       slug: '${{ needs.repos.outputs.slug }}'
       email: '${{ needs.repos.outputs.email }}'
-      regenerate: ${{ github.event.client_payload.regenerate || false }}
+      regenerate: ${{ fromJSON(github.event.client_payload.regenerate) }}
     secrets:
       id: ${{ vars.APP_ID }}
       key: ${{ secrets.PRIVATE_KEY }}

--- a/.github/workflows/rebuild-data.yaml
+++ b/.github/workflows/rebuild-data.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   repos:
-    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/get-installations.yaml@znk/no-token
+    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/get-installations.yaml@main
     with:
       newbies: '${{ toJSON(github.event.client_payload.newbies) }}'
     secrets:
@@ -17,7 +17,7 @@ jobs:
       key: ${{ secrets.PRIVATE_KEY }}
   site:
     needs: [repos]
-    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/generate-data.yaml@znk/no-token
+    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/generate-data.yaml@main
     with:
       repos: '${{ needs.repos.outputs.repos }}'
       slug: '${{ needs.repos.outputs.slug }}'

--- a/.github/workflows/rebuild-data.yaml
+++ b/.github/workflows/rebuild-data.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   repos:
-    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/get-installations.yaml@main
+    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/get-installations.yaml@znk/no-token
     with:
       newbies: '${{ toJSON(github.event.client_payload.newbies) }}'
     secrets:
@@ -17,7 +17,7 @@ jobs:
       key: ${{ secrets.PRIVATE_KEY }}
   site:
     needs: [repos]
-    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/generate-data.yaml@main
+    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/generate-data.yaml@znk/no-token
     with:
       repos: '${{ needs.repos.outputs.repos }}'
       slug: '${{ needs.repos.outputs.slug }}'

--- a/.github/workflows/rebuild-data.yaml
+++ b/.github/workflows/rebuild-data.yaml
@@ -22,7 +22,7 @@ jobs:
       repos: '${{ needs.repos.outputs.repos }}'
       slug: '${{ needs.repos.outputs.slug }}'
       email: '${{ needs.repos.outputs.email }}'
-      regenerate: ${{ fromJSON(github.event.client_payload.regenerate) }}
+      regenerate: ${{ github.event.client_payload.regenerate || false }}
     secrets:
       id: ${{ vars.APP_ID }}
       key: ${{ secrets.PRIVATE_KEY }}

--- a/.github/workflows/rebuild-site.yaml
+++ b/.github/workflows/rebuild-site.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   repos:
-    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/get-installations.yaml@znk/no-token
+    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/get-installations.yaml@main
     with:
       newbies: '${{ toJSON(github.event.client_payload.newbies) }}'
     secrets:
@@ -14,7 +14,7 @@ jobs:
       key: ${{ secrets.PRIVATE_KEY }}
   site:
     needs: [repos]
-    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/generate-site.yaml@znk/no-token
+    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/generate-site.yaml@main
     with:
       repos: '${{ needs.repos.outputs.repos }}'
       slug: '${{ needs.repos.outputs.slug }}'

--- a/.github/workflows/rebuild-site.yaml
+++ b/.github/workflows/rebuild-site.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   repos:
-    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/get-installations.yaml@main
+    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/get-installations.yaml@znk/no-token
     with:
       newbies: '${{ toJSON(github.event.client_payload.newbies) }}'
     secrets:
@@ -14,7 +14,7 @@ jobs:
       key: ${{ secrets.PRIVATE_KEY }}
   site:
     needs: [repos]
-    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/generate-site.yaml@main
+    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/generate-site.yaml@znk/no-token
     with:
       repos: '${{ needs.repos.outputs.repos }}'
       slug: '${{ needs.repos.outputs.slug }}'

--- a/appHelper.py
+++ b/appHelper.py
@@ -61,7 +61,7 @@ def get_slug_id():
     app = ghapp["app"]
     app_usr = gh.get_user(app.slug+"[bot]")
     email = f'{app_usr.id}+{app_usr.login}@users.noreply.github.com'
-    write_string("slug", app.slug)
+    write_string("slug", app.slug + "[bot]")
     write_string("email", email)
     write_string("id", app_usr.id)
 

--- a/scripts/check-branch.sh
+++ b/scripts/check-branch.sh
@@ -16,7 +16,7 @@ if [[ "$exists" != "${branch}" ]]; then
   git init
   git switch -c "${branch}"
   git remote add origin https://${slug}:${token}@github.com/${repo}.git
-  git commit --allow-empty -m 'initial ${branch} commit'
+  git commit --allow-empty -m "initial ${branch} commit"
   git push --set-upstream origin "${branch}"
   cd
 fi

--- a/scripts/check-branch.sh
+++ b/scripts/check-branch.sh
@@ -11,11 +11,11 @@ exists=$(gh api -X GET "repos/${repo}/branches" --jq '.[].name | select(. == "${
 if [[ "$exists" != "${branch}" ]]; then
   tmp=$(mktemp --directory)
   cd "$tmp"
-  git config --global user.name "${slug}[bot]"
+  git config --global user.name "${slug}"
   git config --global user.email "${email}"
   git init
   git switch -c "${branch}"
-  git remote add origin https://${slug}[bot]:${token}@github.com/${repo}.git
+  git remote add origin https://${slug}:${token}@github.com/${repo}.git
   git commit --allow-empty -m 'initial ${branch} commit'
   git push --set-upstream origin "${branch}"
   cd

--- a/scripts/pushit.sh
+++ b/scripts/pushit.sh
@@ -17,9 +17,9 @@ else
 fi
 
 cd "$dir" || (echo "Directory '$dir' not found" && exit 1)
-git config --global user.name "${slug}[bot]"
+git config --global user.name "${slug}"
 git config --global user.email "${email}"
-git remote set-url origin "https://${slug}[bot]:${token}@github.com/${repo}.git"
+git remote set-url origin "https://${slug}:${token}@github.com/${repo}.git"
 ls
 git status
 if [[ "${amend}" == "true" ]]; then


### PR DESCRIPTION
Based on the feedback in https://github.com/reichlab/decisions/pull/5 and from many discussions with @elray, I have modified these workflows to be fully compatible as re-usable workflows without the need for an app.

I have created an example of these workflows in practice in https://github.com/zkamvar/hub-dashboard-workflow:

 - [rebuild-site.yaml](https://github.com/zkamvar/hub-dashboard-workflow/blob/23af1fcc2c1631f3be4afcba0746401971a40a53/.github/workflows/rebuild-site.yaml) will rebuild on each push and on workflow dispatch
 - [rebuild-data.yaml](https://github.com/zkamvar/hub-dashboard-workflow/blob/23af1fcc2c1631f3be4afcba0746401971a40a53/.github/workflows/rebuild-data.yaml) will rebuild on a schedule and on workflow dispatch

I'm also going to make a squash commit for this because there was _a lot_ of trial and error. 

NOTE: when this gets merged, I need to remove the `znk/no-token` branch from the caller workflows