### PR TITLE
Add hubEvals data generation to data workflow

### DIFF
--- a/.github/workflows/filter-matrix.yaml
+++ b/.github/workflows/filter-matrix.yaml
@@ -1,0 +1,47 @@
+name: "Filter Matrix Jobs"
+defaults:
+  run:
+    shell: bash
+on:
+  workflow_call:
+    inputs:
+      artifact:
+        required: true
+        type: string
+    outputs:
+      matrix:
+        description: "A JSON list containing the filtered jobs that can be run furhter"
+        value: ${{ jobs.check.outputs.mat }}
+      process:
+        description: "A boolean value indicating that the result should be processed"
+        value: ${{ jobs.check.outputs.process }}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      mat: ${{ steps.list.outputs.ok }}
+      process: ${{ steps.list.outputs.process }}
+    steps:
+      - id: fetch-artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: results
+          pattern: ${{ inputs.artifact }}
+          merge-multiple: true
+      - id: list
+        run: |
+          if [[ ! -d results ]]; then
+            echo "process=false" >> "$GITHUB_OUTPUT"
+            echo "ok=[]" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "process=true" >> "$GITHUB_OUTPUT"
+          res=(results/*)
+          cat ${res[0]}
+          {
+            echo "ok<<EOF"
+            # combine the files in results into one array
+            jq '.' results/* | jq -s .
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/filter-matrix.yaml
+++ b/.github/workflows/filter-matrix.yaml
@@ -10,7 +10,7 @@ on:
         type: string
     outputs:
       matrix:
-        description: "A JSON list containing the filtered jobs that can be run furhter"
+        description: "A JSON list containing the filtered jobs that can be run further"
         value: ${{ jobs.check.outputs.mat }}
       process:
         description: "A boolean value indicating that the result should be processed"

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -282,7 +282,8 @@ jobs:
       - id: checkout-this-here-repo-scripts
         uses: actions/checkout@v4
         with:
-          repository: hubverse-org/hub-dashboard-control-room@znk/hub-evals
+          repository: hubverse-org/hub-dashboard-control-room
+          ref: znk/hub-evals
           persist-credentials: false
           sparse-checkout: |
             scripts

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -277,7 +277,7 @@ jobs:
       matrix: 
         site: ${{ fromJSON(inputs.repos) }}
     with:
-      is_bot: ${{ needs.check.outputs.exists }}
+      is_bot: ${{ toJSON(needs.check.outputs.exists) }}
       branch: "ptc/data"
       artifact: ${{ matrix.owner }}-${{ matrix.name }}-ptc
       owner: ${{ matrix.owner }}
@@ -292,7 +292,7 @@ jobs:
       matrix:
         site: ${{ fromJSON(inputs.repos) }}
     with:
-      is_bot: ${{ needs.check.outputs.exists }}
+      is_bot: ${{ toJSON(needs.check.outputs.exists) }}
       branch: "predeval/data"
       artifact: ${{ matrix.owner }}-${{ matrix.name }}-predeval
       owner: ${{ matrix.owner }}

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -70,6 +70,14 @@ jobs:
           name="${{ matrix.site.name }}"
           echo "repo=$owner/$name" >> $GITHUB_OUTPUT
           echo "file=$owner-$name-evals" >> $GITHUB_OUTPUT
+      - uses: actions/create-github-app-token@v1
+        if: ${{ fromJSON(needs.check.outputs.exists) }}
+        id: token
+        with:
+          app-id: ${{ secrets.id }}
+          private-key: ${{ secrets.key }}
+          owner: ${{ matrix.site.owner }}
+          repositories: ${{ matrix.site.name }}
       - id: checkout-config
         name: "Fetch config files"
         uses: actions/checkout@v4

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -70,7 +70,7 @@ jobs:
           owner="${{ matrix.site.owner }}"
           name="${{ matrix.site.name }}"
           echo "repo=$owner/$name" >> $GITHUB_OUTPUT
-          echo "file=$owner-$name-predeval" >> $GITHUB_OUTPUT
+          echo "file=$owner-$name-predeval-data" >> $GITHUB_OUTPUT
       - uses: actions/create-github-app-token@v1
         if: ${{ fromJSON(needs.check.outputs.exists) }}
         id: token
@@ -99,7 +99,7 @@ jobs:
             echo "::notice title=Missing config ($repo)::No predeval-config.yml file found. Exiting."
             exit 0
           fi
-          file=evals-${{ env.KEY }}
+          file=predeval-${{ env.KEY }}
           touch "$file"
           {
             echo '${{ toJSON(matrix.site) }}'
@@ -109,8 +109,8 @@ jobs:
         if: ${{ fromJSON(steps.status-check.outputs.ok) }}
         uses: actions/upload-artifact@v4
         with:
-          name: evals-${{ env.KEY }}
-          path: evals-${{ env.KEY }}
+          name: predeval-${{ env.KEY }}
+          path: predeval-${{ env.KEY }}
       - id: check-branch
         if: ${{ fromJSON(steps.status-check.outputs.ok) }}
         name: "check for predeval/data branch"
@@ -192,7 +192,7 @@ jobs:
           owner="${{ matrix.site.owner }}"
           name="${{ matrix.site.name }}"
           echo "repo=$owner/$name" >> $GITHUB_OUTPUT
-          echo "file=$owner-$name-ptc" >> $GITHUB_OUTPUT
+          echo "file=$owner-$name-ptc-data" >> $GITHUB_OUTPUT
       - uses: actions/create-github-app-token@v1
         if: ${{ fromJSON(needs.check.outputs.exists) }}
         id: token
@@ -317,86 +317,38 @@ jobs:
           name: ${{ steps.id.outputs.file }}
           path: 'out/'
   check-forecasts:
-    runs-on: ubuntu-latest
     needs: [build-forecasts]
-    outputs:
-      mat: ${{ steps.list.outputs.ok }}
-      process: ${{ steps.list.outputs.process }}
-    steps:
-      - id: fetch-artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: results
-          pattern: ptc-*
-          merge-multiple: true
-      - id: list
-        run: |
-          if [[ ! -d results ]]; then
-            echo "process=false" >> "$GITHUB_OUTPUT"
-            echo "ok=[]" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "process=true" >> "$GITHUB_OUTPUT"
-          res=(results/*)
-          cat ${res[0]}
-          {
-            echo "ok<<EOF"
-            # combine the files in results into one array
-            jq '.' results/* | jq -s .
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/filter-matrix.yaml@znk/hub-evals
+    with:
+      artifact: "ptc-*"
   push-ptc-data:
     needs: [check, check-forecasts]
     if: ${{ needs.check-forecasts.outputs.process }}
     uses: hubverse-org/hub-dashboard-control-room/.github/workflows/push-things.yaml@znk/hub-evals
-    strategy: 
-      matrix: 
-        site: ${{ fromJSON(needs.check-forecasts.outputs.mat) }}
+    strategy:
+      matrix:
+        site: ${{ fromJSON(needs.check-forecasts.outputs.matrix) }}
     with:
       is_bot: ${{ fromJSON(needs.check.outputs.exists) }}
       branch: "ptc/data"
-      artifact: ${{ matrix.site.owner }}-${{ matrix.site.name }}-ptc
+      artifact: ${{ matrix.site.owner }}-${{ matrix.site.name }}-ptc-data
       owner: ${{ matrix.site.owner }}
       name: ${{ matrix.site.name }}
       slug: ${{ inputs.slug }}
       email: ${{ inputs.email }}
     secrets: inherit
   check-predeval:
-    runs-on: ubuntu-latest
     needs: [build-evals]
-    outputs:
-      mat: ${{ steps.list.outputs.ok }}
-      process: ${{ steps.list.outputs.process }}
-    steps:
-      - id: fetch-artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: results
-          pattern: evals-*
-          merge-multiple: true
-      - id: list
-        run: |
-          if [[ ! -d results ]]; then
-            echo "process=false" >> "$GITHUB_OUTPUT"
-            echo "ok=[]" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "process=true" >> "$GITHUB_OUTPUT"
-          res=(results/*)
-          cat ${res[0]}
-          {
-            echo "ok<<EOF"
-            # combine the files in results into one array
-            jq '.' results/* | jq -s .
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/filter-matrix.yaml@znk/hub-evals
+    with:
+      artifact: "predeval-*"
   push-predeval-data:
     needs: [check, check-predeval]
     if: ${{ needs.check-predeval.outputs.process }}
     uses: hubverse-org/hub-dashboard-control-room/.github/workflows/push-things.yaml@znk/hub-evals
     strategy:
       matrix:
-        site: ${{ fromJSON(needs.check-predeval.outputs.mat) }}
+        site: ${{ fromJSON(needs.check-predeval.outputs.matrix) }}
     with:
       is_bot: ${{ fromJSON(needs.check.outputs.exists) }}
       branch: "predeval/data"

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -38,7 +38,7 @@ jobs:
           fi
           echo "bot=$bot" >> "$GITHUB_OUTPUT"
         shell: bash
-  build-data:
+  build-forecasts:
     needs: [check]
     name: "Generate Forecast Page Data"
     runs-on: ubuntu-latest
@@ -167,7 +167,7 @@ jobs:
   push-data:
     name: "Push Forecast Data"
     runs-on: ubuntu-latest
-    needs: [check, build-data]
+    needs: [check, build-forecasts]
     continue-on-error: true
     strategy: 
       matrix: 

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -89,7 +89,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.token.outputs.token || secrets.key }}
         run: | 
-          exists=$(gh api -X GET "repos/${{ steps.id.outputs.repo }}/branches" --jq '.[].name | select(. == "predevals/data")')
+          exists=$(curl -sSL "https://api.github.com/repos/${{ steps.id.outputs.repo }}/branches" | jq '.[].name | select(. == "predevals/data")')
           if [[ "$exists" = "predevals/data" ]]; then
             fetch=true
           else

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -282,7 +282,7 @@ jobs:
       - id: checkout-this-here-repo-scripts
         uses: actions/checkout@v4
         with:
-          repository: hubverse-org/hub-dashboard-control-room
+          repository: hubverse-org/hub-dashboard-control-room@znk/hub-evals
           persist-credentials: false
           sparse-checkout: |
             scripts

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -38,6 +38,105 @@ jobs:
           fi
           echo "bot=$bot" >> "$GITHUB_OUTPUT"
         shell: bash
+  build-evals:
+    needs: [check]
+    name: "Generate Eval Page Data"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        site: ${{ fromJSON(inputs.repos) }}
+    container:
+      image: ghcr.io/hubverse-org/hubpredevalsdata-docker:main
+      ports:
+        - 80
+      volumes:
+        - ${{ github.workspace }}:/project
+    steps:
+      - id: id
+        name: "setup run variables"
+        run: |
+          if [[ -n "${{ matrix.site.build }}" ]]; then
+            echo "build=${{ matrix.site.build }}" >> $GITHUB_OUTPUT
+          else
+            echo "build=both" >> $GITHUB_OUTPUT
+          fi
+          owner="${{ matrix.site.owner }}"
+          name="${{ matrix.site.name }}"
+          echo "repo=$owner/$name" >> $GITHUB_OUTPUT
+          echo "file=$owner-$name-evals" >> $GITHUB_OUTPUT
+      - id: checkout-config
+        name: "Fetch config files"
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          token: ${{ steps.token.outputs.token || secrets.key }}
+          repository: ${{ steps.id.outputs.repo }}
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            predeval-config.yml
+            site-config.yml
+      - id: check-configs
+        name: "Check if we need to build data"
+        shell: "bash"
+        run: |
+          if [[ ! -f predeval-config.yml ]]; then
+            echo "::error title=Missing config (${{ steps.id.outputs.repo }})::No predeval-config.yml file found. Exiting."
+            exit 1
+          fi
+      - id: check-branch
+        name: "check for predevals/data branch"
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token || secrets.key }}
+        run: | 
+          exists=$(gh api -X GET "repos/${{ steps.id.outputs.repo }}/branches" --jq '.[].name | select(. == "predevals/data")')
+          if [[ "$exists" = "predevals/data" ]]; then
+            fetch=true
+          else
+            fetch=false
+          fi
+          echo "fetch=$fetch" >> "$GITHUB_OUTPUT"
+      - id: checkout-data
+        if: ${{ fromJSON(steps.check-branch.outputs.fetch) }}
+        name: "Checkout predevals/data branch"
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.token.outputs.token || secrets.key }}
+          persist-credentials: false
+          repository: ${{ steps.id.outputs.repo }}
+          ref: 'predevals/data'
+          path: 'out'
+      - id: get-repo-name
+        name: "Get information about hub"
+        run: |
+          mkdir -p out/
+          yq eval '.hub' site-config.yml \
+          | sed -E -e 's+(https://github.com/|^)+repo=+' \
+          | sed -E -e 's+[/]$++' >> $GITHUB_OUTPUT
+      - id: clone-repo
+        name: "Fetch ${{ steps.get-repo-name.outputs.repo }}"
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          repository: ${{ steps.get-repo-name.outputs.repo }}
+          path: 'repo'
+      - id: build-targets
+        name: "Generate scores data"
+        if: ${{ steps.id.outputs.build == 'both' || steps.id.outputs.build == 'target' }}
+        run: |
+          prefix="https://raw.githubusercontent.com/${{ steps.id.outputs.repo }}/refs/heads"
+          oracle="${prefix}/oracle-data/oracle-output.csv"
+          create-predevals-data.R \
+          -h repo \
+          -c predeval-config.yml \
+          -d $oracle \
+          -o out
+      - name: Upload artifact
+        id: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.id.outputs.file }}
+          path: 'out/'
   build-forecasts:
     needs: [check]
     name: "Generate Forecast Page Data"

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -277,7 +277,7 @@ jobs:
       matrix: 
         site: ${{ fromJSON(inputs.repos) }}
     with:
-      is_bot: ${{ toJSON(needs.check.outputs.exists) }}
+      is_bot: ${{ fromJSON(needs.check.outputs.exists) }}
       branch: "ptc/data"
       artifact: ${{ matrix.owner }}-${{ matrix.name }}-ptc
       owner: ${{ matrix.owner }}
@@ -292,7 +292,7 @@ jobs:
       matrix:
         site: ${{ fromJSON(inputs.repos) }}
     with:
-      is_bot: ${{ toJSON(needs.check.outputs.exists) }}
+      is_bot: ${{ fromJSON(needs.check.outputs.exists) }}
       branch: "predeval/data"
       artifact: ${{ matrix.owner }}-${{ matrix.name }}-predeval
       owner: ${{ matrix.owner }}

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -45,6 +45,10 @@ jobs:
     name: "Generate Eval Page Data"
     runs-on: ubuntu-latest
     continue-on-error: true
+    outputs:
+      ok: ${{ fromJSON(steps.status-check.outputs.ok) }}
+    env:
+      KEY: ${{ matrix.site.owner }}-${{ matrix.site.name }}
     strategy:
       matrix:
         site: ${{ fromJSON(inputs.repos) }}
@@ -86,14 +90,29 @@ jobs:
           sparse-checkout: |
             predeval-config.yml
             site-config.yml
-      - id: check-configs
+      - id: status-check
         name: "Check if we need to build data"
         run: |
           if [[ ! -f predeval-config.yml ]]; then
-            echo "::error title=Missing config (${{ steps.id.outputs.repo }})::No predeval-config.yml file found. Exiting."
-            exit 1
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            repo=${{ steps.id.outputs.repo }}
+            echo "::notice title=Missing config ($repo)::No predeval-config.yml file found. Exiting."
+            exit 0
           fi
+          file=evals-${{ env.KEY }}
+          touch "$file"
+          {
+            echo '${{ toJSON(matrix.site) }}'
+          } > "$file"
+          echo "ok=true" >> $GITHUB_OUTPUT
+      - id: upload-status
+        if: ${{ fromJSON(steps.status-check.outputs.ok) }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: evals-${{ env.KEY }}
+          path: evals-${{ env.KEY }}
       - id: check-branch
+        if: ${{ fromJSON(steps.status-check.outputs.ok) }}
         name: "check for predeval/data branch"
         env:
           GH_TOKEN: ${{ steps.token.outputs.token || secrets.key }}
@@ -106,7 +125,7 @@ jobs:
           fi
           echo "fetch=$fetch" >> "$GITHUB_OUTPUT"
       - id: checkout-data
-        if: ${{ fromJSON(steps.check-branch.outputs.fetch) }}
+        if: ${{ fromJSON(steps.status-check.outputs.ok) && fromJSON(steps.check-branch.outputs.fetch) }}
         name: "Checkout predeval/data branch"
         uses: actions/checkout@v4
         with:
@@ -116,6 +135,7 @@ jobs:
           ref: 'predeval/data'
           path: 'out'
       - id: get-repo-name
+        if: ${{ fromJSON(steps.status-check.outputs.ok) }}
         name: "Get information about hub"
         run: |
           mkdir -p out/
@@ -123,6 +143,7 @@ jobs:
           | sed -E -e 's+(https://github.com/|^)+repo=+' \
           | sed -E -e 's+[/]$++' >> $GITHUB_OUTPUT
       - id: clone-repo
+        if: ${{ fromJSON(steps.status-check.outputs.ok) }}
         name: "Fetch ${{ steps.get-repo-name.outputs.repo }}"
         uses: actions/checkout@v4
         with:
@@ -130,6 +151,7 @@ jobs:
           repository: ${{ steps.get-repo-name.outputs.repo }}
           path: 'repo'
       - id: build-targets
+        if: ${{ fromJSON(steps.status-check.outputs.ok) }}
         name: "Generate scores data"
         run: |
           prefix="https://raw.githubusercontent.com/${{ steps.id.outputs.repo }}/refs/heads"
@@ -140,6 +162,7 @@ jobs:
           -d $oracle \
           -o out
       - name: Upload artifact
+        if: ${{ fromJSON(steps.status-check.outputs.ok) }}
         id: upload
         uses: actions/upload-artifact@v4
         with:
@@ -150,6 +173,10 @@ jobs:
     name: "Generate Forecast Page Data"
     runs-on: ubuntu-latest
     continue-on-error: true
+    outputs:
+      ok: ${{ fromJSON(steps.status-check.outputs.ok) }}
+    env:
+      KEY: ${{ matrix.site.owner }}-${{ matrix.site.name }}
     strategy:
       matrix:
         site: ${{ fromJSON(inputs.repos) }}
@@ -166,15 +193,6 @@ jobs:
           name="${{ matrix.site.name }}"
           echo "repo=$owner/$name" >> $GITHUB_OUTPUT
           echo "file=$owner-$name-ptc" >> $GITHUB_OUTPUT
-      - id: setup-snake
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.12
-      - id: install-predtimechart-tool
-        name: "Install predtimechart conversion tool"
-        run: |
-          pip install --upgrade pip
-          pip install git+https://github.com/hubverse-org/hub-dashboard-predtimechart
       - uses: actions/create-github-app-token@v1
         if: ${{ fromJSON(needs.check.outputs.exists) }}
         id: token
@@ -194,14 +212,39 @@ jobs:
           sparse-checkout: |
             predtimechart-config.yml
             site-config.yml
-      - id: check-configs
+      - id: status-check
         name: "Check if we need to build data"
         run: |
           if [[ ! -f predtimechart-config.yml ]]; then
-            echo "::error title=Missing config (${{ steps.id.outputs.repo }})::No predtimechart-config.yml file found. Exiting."
-            exit 1
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            repo=${{ steps.id.outputs.repo }}
+            echo "::notice title=Missing config ($repo)::No predtimechart-config.yml file found. Exiting."
+            exit 0
           fi
+          file=ptc-${{ env.KEY }}
+          touch "$file"
+          {
+            echo '${{ toJSON(matrix.site) }}'
+          } > "$file"
+          echo "ok=true" >> $GITHUB_OUTPUT
+      - id: setup-snake
+        if: ${{ fromJSON(steps.status-check.outputs.ok) }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - id: install-predtimechart-tool
+        name: "Install predtimechart conversion tool"
+        run: |
+          pip install --upgrade pip
+          pip install git+https://github.com/hubverse-org/hub-dashboard-predtimechart
+      - id: upload-status
+        if: ${{ fromJSON(steps.status-check.outputs.ok) }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ptc-${{ env.KEY }}
+          path: ptc-${{ env.KEY }}
       - id: check-branch
+        if: ${{ fromJSON(steps.status-check.outputs.ok) }}
         name: "check for ptc/data branch"
         env:
           GH_TOKEN: ${{ steps.token.outputs.token || secrets.key }}
@@ -214,7 +257,7 @@ jobs:
           fi
           echo "fetch=$fetch" >> "$GITHUB_OUTPUT"
       - id: checkout-data
-        if: ${{ fromJSON(steps.check-branch.outputs.fetch) }}
+        if: ${{ fromJSON(steps.status-check.outputs.ok) && fromJSON(steps.check-branch.outputs.fetch) }}
         name: "Checkout ptc/data branch"
         uses: actions/checkout@v4
         with:
@@ -224,6 +267,7 @@ jobs:
           ref: 'ptc/data'
           path: 'out'
       - id: get-repo-name
+        if: ${{ fromJSON(steps.status-check.outputs.ok) }}
         name: "Get information about hub"
         run: |
           mkdir -p out/targets/
@@ -232,6 +276,7 @@ jobs:
           | sed -E -e 's+(https://github.com/|^)+repo=+' \
           | sed -E -e 's+[/]$++' >> $GITHUB_OUTPUT
       - id: clone-repo
+        if: ${{ fromJSON(steps.status-check.outputs.ok) }}
         name: "Fetch ${{ steps.get-repo-name.outputs.repo }}"
         uses: actions/checkout@v4
         with:
@@ -240,14 +285,14 @@ jobs:
           path: 'repo'
       - id: build-targets
         name: "Generate target data"
-        if: ${{ steps.id.outputs.build == 'both' || steps.id.outputs.build == 'target' }}
+        if: ${{ fromJSON(steps.status-check.outputs.ok) && steps.id.outputs.build == 'both' || steps.id.outputs.build == 'target' }}
         run: |
           ptc_generate_target_json_files \
             repo \
             predtimechart-config.yml \
             out/targets
       - id: json-lives
-        if: ${{ steps.id.outputs.build == 'both' || steps.id.outputs.build == 'forecast' }}
+        if: ${{ fromJSON(steps.status-check.outputs.ok) && steps.id.outputs.build == 'both' || steps.id.outputs.build == 'forecast' }}
         name: "Generate forecast data"
         run: |
           if [[ ${{ inputs.regenerate }} == 'true' ]]; then
@@ -265,17 +310,48 @@ jobs:
               out/forecasts
           fi
       - name: Upload artifact
+        if: ${{ fromJSON(steps.status-check.outputs.ok) }}
         id: upload
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.id.outputs.file }}
           path: 'out/'
+  check-forecasts:
+    runs-on: ubuntu-latest
+    needs: [build-forecasts]
+    outputs:
+      mat: ${{ steps.list.outputs.ok }}
+      process: ${{ steps.list.outputs.process }}
+    steps:
+      - id: fetch-artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: results
+          pattern: ptc-*
+          merge-multiple: true
+      - id: list
+        run: |
+          if [[ ! -d results ]]; then
+            echo "process=false" >> "$GITHUB_OUTPUT"
+            echo "ok=[]" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "process=true" >> "$GITHUB_OUTPUT"
+          res=(results/*)
+          cat ${res[0]}
+          {
+            echo "ok<<EOF"
+            # combine the files in results into one array
+            jq '.' results/* | jq -s .
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
   push-ptc-data:
-    needs: [check, build-forecasts]
+    needs: [check, check-forecasts]
+    if: ${{ needs.check-forecasts.outputs.process }}
     uses: hubverse-org/hub-dashboard-control-room/.github/workflows/push-things.yaml@znk/hub-evals
     strategy: 
       matrix: 
-        site: ${{ fromJSON(inputs.repos) }}
+        site: ${{ fromJSON(needs.check-forecasts.outputs.mat) }}
     with:
       is_bot: ${{ fromJSON(needs.check.outputs.exists) }}
       branch: "ptc/data"
@@ -285,12 +361,42 @@ jobs:
       slug: ${{ inputs.slug }}
       email: ${{ inputs.email }}
     secrets: inherit
+  check-predeval:
+    runs-on: ubuntu-latest
+    needs: [build-evals]
+    outputs:
+      mat: ${{ steps.list.outputs.ok }}
+      process: ${{ steps.list.outputs.process }}
+    steps:
+      - id: fetch-artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: results
+          pattern: evals-*
+          merge-multiple: true
+      - id: list
+        run: |
+          if [[ ! -d results ]]; then
+            echo "process=false" >> "$GITHUB_OUTPUT"
+            echo "ok=[]" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "process=true" >> "$GITHUB_OUTPUT"
+          res=(results/*)
+          cat ${res[0]}
+          {
+            echo "ok<<EOF"
+            # combine the files in results into one array
+            jq '.' results/* | jq -s .
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
   push-predeval-data:
-    needs: [check, build-evals]
+    needs: [check, check-predeval]
+    if: ${{ needs.check-predeval.outputs.process }}
     uses: hubverse-org/hub-dashboard-control-room/.github/workflows/push-things.yaml@znk/hub-evals
     strategy:
       matrix:
-        site: ${{ fromJSON(inputs.repos) }}
+        site: ${{ fromJSON(needs.check-predeval.outputs.mat) }}
     with:
       is_bot: ${{ fromJSON(needs.check.outputs.exists) }}
       branch: "predeval/data"
@@ -300,105 +406,3 @@ jobs:
       slug: ${{ inputs.slug }}
       email: ${{ inputs.email }}
     secrets: inherit
-
-
-
-    # name: "Push Data"
-    # runs-on: ubuntu-latest
-    # needs: [check, build-forecasts, build-evals]
-    # continue-on-error: true
-    # strategy: 
-    #   matrix: 
-    #     site: ${{ fromJSON(inputs.repos) }}
-    # steps:
-    #   - id: checkout-this-here-repo-scripts
-    #     uses: actions/checkout@v4
-    #     with:
-    #       repository: hubverse-org/hub-dashboard-control-room
-    #       ref: znk/hub-evals
-    #       persist-credentials: false
-    #       sparse-checkout: |
-    #         scripts
-    #   - id: id
-    #     name: "setup run variables"
-    #     run: |
-    #       owner="${{ matrix.site.owner }}"
-    #       name="${{ matrix.site.name }}"
-    #       echo "repo=$owner/$name" >> $GITHUB_OUTPUT
-    #       echo "ptc-file=$owner-$name-data" >> $GITHUB_OUTPUT
-    #       echo "predevals-file=$owner-$name-evals" >> $GITHUB_OUTPUT
-    #   - uses: actions/create-github-app-token@v1
-    #     if: ${{ fromJSON(needs.check.outputs.exists) }}
-    #     id: token
-    #     with:
-    #       app-id: ${{ secrets.id }}
-    #       private-key: ${{ secrets.key }}
-    #       owner: ${{ matrix.site.owner }}
-    #       repositories: ${{ matrix.site.name }}
-    #   - id: check-ptc-branch
-    #     env:
-    #       GH_TOKEN: ${{ github.token }}
-    #     name: "check for ptc/data branch and create if needed"
-    #     run: | 
-    #       bash -x "${{ github.workspace }}/scripts/check-branch.sh" \
-    #         "ptc/data" \
-    #         "${{ steps.id.outputs.repo }}" \
-    #         "${{ inputs.slug }}" \
-    #         "${{ inputs.email }}" \
-    #         "${{ steps.token.outputs.token || secrets.key }}"
-    #   - id: checkout-ptc-data
-    #     uses: actions/checkout@v4
-    #     with:
-    #       persist-credentials: false
-    #       repository: ${{ steps.id.outputs.repo }}
-    #       ref: ptc/data
-    #       path: 'data'
-    #       token: ${{ steps.token.outputs.token || secrets.key }}
-    #   - id: ptc-fetch-artifact
-    #     uses: actions/download-artifact@v4
-    #     with:
-    #       name: ${{ steps.id.outputs.ptc-file }}
-    #   - id: ptc-publish
-    #     name: "Publish to ptc/data branch"
-    #     run: | 
-    #       ls -larth
-    #       bash -x "${{ github.workspace }}/scripts/pushit.sh" \
-    #         "ptc/data" \
-    #         "${{ steps.id.outputs.repo }}" \
-    #         "${{ inputs.slug }}" \
-    #         "${{ inputs.email }}" \
-    #         "${{ steps.token.outputs.token || secrets.key }}" \
-    #       && rm -rf data
-    #   - id: check-predevals-branch
-    #     env:
-    #       GH_TOKEN: ${{ github.token }}
-    #     name: "check for predeval/data branch and create if needed"
-    #     run: |
-    #       bash -x "${{ github.workspace }}/scripts/check-branch.sh" \
-    #         "predeval/data" \
-    #         "${{ steps.id.outputs.repo }}" \
-    #         "${{ inputs.slug }}" \
-    #         "${{ inputs.email }}" \
-    #         "${{ steps.token.outputs.token || secrets.key }}"
-    #   - id: checkout-predevals-data
-    #     uses: actions/checkout@v4
-    #     with:
-    #       persist-credentials: false
-    #       repository: ${{ steps.id.outputs.repo }}
-    #       ref: predeval/data
-    #       path: 'data'
-    #       token: ${{ steps.token.outputs.token || secrets.key }}
-    #   - id: predevals-fetch-artifact
-    #     uses: actions/download-artifact@v4
-    #     with:
-    #       name: ${{ steps.id.outputs.predevals-file }}
-    #   - id: predevals-publish
-    #     name: "Publish to predeval/data branch"
-    #     run: | 
-    #       ls -larth
-    #       bash -x "${{ github.workspace }}/scripts/pushit.sh" \
-    #         "predeval/data" \
-    #         "${{ steps.id.outputs.repo }}" \
-    #         "${{ inputs.slug }}" \
-    #         "${{ inputs.email }}" \
-    #         "${{ steps.token.outputs.token || secrets.key }}"

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -279,9 +279,9 @@ jobs:
     with:
       is_bot: ${{ fromJSON(needs.check.outputs.exists) }}
       branch: "ptc/data"
-      artifact: ${{ matrix.owner }}-${{ matrix.name }}-ptc
-      owner: ${{ matrix.owner }}
-      name: ${{ matrix.name }}
+      artifact: ${{ matrix.site.owner }}-${{ matrix.site.name }}-ptc
+      owner: ${{ matrix.site.owner }}
+      name: ${{ matrix.site.name }}
       slug: ${{ inputs.slug }}
       email: ${{ inputs.email }}
     secrets: inherit
@@ -294,9 +294,9 @@ jobs:
     with:
       is_bot: ${{ fromJSON(needs.check.outputs.exists) }}
       branch: "predeval/data"
-      artifact: ${{ matrix.owner }}-${{ matrix.name }}-predeval
-      owner: ${{ matrix.owner }}
-      name: ${{ matrix.name }}
+      artifact: ${{ matrix.site.owner }}-${{ matrix.site.name }}-predeval
+      owner: ${{ matrix.site.owner }}
+      name: ${{ matrix.site.name }}
       slug: ${{ inputs.slug }}
       email: ${{ inputs.email }}
     secrets: inherit

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -126,7 +126,7 @@ jobs:
         run: |
           prefix="https://raw.githubusercontent.com/${{ steps.id.outputs.repo }}/refs/heads"
           oracle="${prefix}/oracle-data/oracle-output.csv"
-          create-predevals-data.R \
+          create-predeval-data.R \
           -h repo \
           -c predeval-config.yml \
           -d $oracle \

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -96,6 +96,7 @@ jobs:
             fetch=false
           fi
           echo "fetch=$fetch" >> "$GITHUB_OUTPUT"
+        shell: bash
       - id: checkout-data
         if: ${{ fromJSON(steps.check-branch.outputs.fetch) }}
         name: "Checkout predevals/data branch"

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -66,7 +66,7 @@ jobs:
           owner="${{ matrix.site.owner }}"
           name="${{ matrix.site.name }}"
           echo "repo=$owner/$name" >> $GITHUB_OUTPUT
-          echo "file=$owner-$name-evals" >> $GITHUB_OUTPUT
+          echo "file=$owner-$name-predeval" >> $GITHUB_OUTPUT
       - uses: actions/create-github-app-token@v1
         if: ${{ fromJSON(needs.check.outputs.exists) }}
         id: token
@@ -165,7 +165,7 @@ jobs:
           owner="${{ matrix.site.owner }}"
           name="${{ matrix.site.name }}"
           echo "repo=$owner/$name" >> $GITHUB_OUTPUT
-          echo "file=$owner-$name-data" >> $GITHUB_OUTPUT
+          echo "file=$owner-$name-ptc" >> $GITHUB_OUTPUT
       - id: setup-snake
         uses: actions/setup-python@v5
         with:
@@ -270,103 +270,135 @@ jobs:
         with:
           name: ${{ steps.id.outputs.file }}
           path: 'out/'
-  push-data:
-    name: "Push Data"
-    runs-on: ubuntu-latest
-    needs: [check, build-forecasts, build-evals]
-    continue-on-error: true
+  push-ptc-data:
+    needs: [check, build-forecasts]
+    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/push-things.yaml@znk/hub-evals
     strategy: 
       matrix: 
         site: ${{ fromJSON(inputs.repos) }}
-    steps:
-      - id: checkout-this-here-repo-scripts
-        uses: actions/checkout@v4
-        with:
-          repository: hubverse-org/hub-dashboard-control-room
-          ref: znk/hub-evals
-          persist-credentials: false
-          sparse-checkout: |
-            scripts
-      - id: id
-        name: "setup run variables"
-        run: |
-          owner="${{ matrix.site.owner }}"
-          name="${{ matrix.site.name }}"
-          echo "repo=$owner/$name" >> $GITHUB_OUTPUT
-          echo "ptc-file=$owner-$name-data" >> $GITHUB_OUTPUT
-          echo "predevals-file=$owner-$name-evals" >> $GITHUB_OUTPUT
-      - uses: actions/create-github-app-token@v1
-        if: ${{ fromJSON(needs.check.outputs.exists) }}
-        id: token
-        with:
-          app-id: ${{ secrets.id }}
-          private-key: ${{ secrets.key }}
-          owner: ${{ matrix.site.owner }}
-          repositories: ${{ matrix.site.name }}
-      - id: check-ptc-branch
-        env:
-          GH_TOKEN: ${{ github.token }}
-        name: "check for ptc/data branch and create if needed"
-        run: | 
-          bash -x "${{ github.workspace }}/scripts/check-branch.sh" \
-            "ptc/data" \
-            "${{ steps.id.outputs.repo }}" \
-            "${{ inputs.slug }}" \
-            "${{ inputs.email }}" \
-            "${{ steps.token.outputs.token || secrets.key }}"
-      - id: checkout-ptc-data
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          repository: ${{ steps.id.outputs.repo }}
-          ref: ptc/data
-          path: 'data'
-          token: ${{ steps.token.outputs.token || secrets.key }}
-      - id: ptc-fetch-artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ steps.id.outputs.ptc-file }}
-      - id: ptc-publish
-        name: "Publish to ptc/data branch"
-        run: | 
-          ls -larth
-          bash -x "${{ github.workspace }}/scripts/pushit.sh" \
-            "ptc/data" \
-            "${{ steps.id.outputs.repo }}" \
-            "${{ inputs.slug }}" \
-            "${{ inputs.email }}" \
-            "${{ steps.token.outputs.token || secrets.key }}" \
-          && rm -rf data
-      - id: check-predevals-branch
-        env:
-          GH_TOKEN: ${{ github.token }}
-        name: "check for predeval/data branch and create if needed"
-        run: |
-          bash -x "${{ github.workspace }}/scripts/check-branch.sh" \
-            "predeval/data" \
-            "${{ steps.id.outputs.repo }}" \
-            "${{ inputs.slug }}" \
-            "${{ inputs.email }}" \
-            "${{ steps.token.outputs.token || secrets.key }}"
-      - id: checkout-predevals-data
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          repository: ${{ steps.id.outputs.repo }}
-          ref: predeval/data
-          path: 'data'
-          token: ${{ steps.token.outputs.token || secrets.key }}
-      - id: predevals-fetch-artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ steps.id.outputs.predevals-file }}
-      - id: predevals-publish
-        name: "Publish to predeval/data branch"
-        run: | 
-          ls -larth
-          bash -x "${{ github.workspace }}/scripts/pushit.sh" \
-            "predeval/data" \
-            "${{ steps.id.outputs.repo }}" \
-            "${{ inputs.slug }}" \
-            "${{ inputs.email }}" \
-            "${{ steps.token.outputs.token || secrets.key }}"
+    with:
+      is_bot: ${{ needs.check.outputs.exists }}
+      branch: "ptc/data"
+      artifact: ${{ matrix.owner }}-${{ matrix.name }}-ptc
+      owner: ${{ matrix.owner }}
+      name: ${{ matrix.name }}
+      slug: ${{ inputs.slug }}
+      email: ${{ inputs.email }}
+    secrets: inherit
+  push-predeval-data:
+    needs: [check, build-evals]
+    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/push-things.yaml@znk/hub-evals
+    strategy:
+      matrix:
+        site: ${{ fromJSON(inputs.repos) }}
+    with:
+      is_bot: ${{ needs.check.outputs.exists }}
+      branch: "predeval/data"
+      artifact: ${{ matrix.owner }}-${{ matrix.name }}-predeval
+      owner: ${{ matrix.owner }}
+      name: ${{ matrix.name }}
+      slug: ${{ inputs.slug }}
+      email: ${{ inputs.email }}
+    secrets: inherit
+
+
+
+    # name: "Push Data"
+    # runs-on: ubuntu-latest
+    # needs: [check, build-forecasts, build-evals]
+    # continue-on-error: true
+    # strategy: 
+    #   matrix: 
+    #     site: ${{ fromJSON(inputs.repos) }}
+    # steps:
+    #   - id: checkout-this-here-repo-scripts
+    #     uses: actions/checkout@v4
+    #     with:
+    #       repository: hubverse-org/hub-dashboard-control-room
+    #       ref: znk/hub-evals
+    #       persist-credentials: false
+    #       sparse-checkout: |
+    #         scripts
+    #   - id: id
+    #     name: "setup run variables"
+    #     run: |
+    #       owner="${{ matrix.site.owner }}"
+    #       name="${{ matrix.site.name }}"
+    #       echo "repo=$owner/$name" >> $GITHUB_OUTPUT
+    #       echo "ptc-file=$owner-$name-data" >> $GITHUB_OUTPUT
+    #       echo "predevals-file=$owner-$name-evals" >> $GITHUB_OUTPUT
+    #   - uses: actions/create-github-app-token@v1
+    #     if: ${{ fromJSON(needs.check.outputs.exists) }}
+    #     id: token
+    #     with:
+    #       app-id: ${{ secrets.id }}
+    #       private-key: ${{ secrets.key }}
+    #       owner: ${{ matrix.site.owner }}
+    #       repositories: ${{ matrix.site.name }}
+    #   - id: check-ptc-branch
+    #     env:
+    #       GH_TOKEN: ${{ github.token }}
+    #     name: "check for ptc/data branch and create if needed"
+    #     run: | 
+    #       bash -x "${{ github.workspace }}/scripts/check-branch.sh" \
+    #         "ptc/data" \
+    #         "${{ steps.id.outputs.repo }}" \
+    #         "${{ inputs.slug }}" \
+    #         "${{ inputs.email }}" \
+    #         "${{ steps.token.outputs.token || secrets.key }}"
+    #   - id: checkout-ptc-data
+    #     uses: actions/checkout@v4
+    #     with:
+    #       persist-credentials: false
+    #       repository: ${{ steps.id.outputs.repo }}
+    #       ref: ptc/data
+    #       path: 'data'
+    #       token: ${{ steps.token.outputs.token || secrets.key }}
+    #   - id: ptc-fetch-artifact
+    #     uses: actions/download-artifact@v4
+    #     with:
+    #       name: ${{ steps.id.outputs.ptc-file }}
+    #   - id: ptc-publish
+    #     name: "Publish to ptc/data branch"
+    #     run: | 
+    #       ls -larth
+    #       bash -x "${{ github.workspace }}/scripts/pushit.sh" \
+    #         "ptc/data" \
+    #         "${{ steps.id.outputs.repo }}" \
+    #         "${{ inputs.slug }}" \
+    #         "${{ inputs.email }}" \
+    #         "${{ steps.token.outputs.token || secrets.key }}" \
+    #       && rm -rf data
+    #   - id: check-predevals-branch
+    #     env:
+    #       GH_TOKEN: ${{ github.token }}
+    #     name: "check for predeval/data branch and create if needed"
+    #     run: |
+    #       bash -x "${{ github.workspace }}/scripts/check-branch.sh" \
+    #         "predeval/data" \
+    #         "${{ steps.id.outputs.repo }}" \
+    #         "${{ inputs.slug }}" \
+    #         "${{ inputs.email }}" \
+    #         "${{ steps.token.outputs.token || secrets.key }}"
+    #   - id: checkout-predevals-data
+    #     uses: actions/checkout@v4
+    #     with:
+    #       persist-credentials: false
+    #       repository: ${{ steps.id.outputs.repo }}
+    #       ref: predeval/data
+    #       path: 'data'
+    #       token: ${{ steps.token.outputs.token || secrets.key }}
+    #   - id: predevals-fetch-artifact
+    #     uses: actions/download-artifact@v4
+    #     with:
+    #       name: ${{ steps.id.outputs.predevals-file }}
+    #   - id: predevals-publish
+    #     name: "Publish to predeval/data branch"
+    #     run: | 
+    #       ls -larth
+    #       bash -x "${{ github.workspace }}/scripts/pushit.sh" \
+    #         "predeval/data" \
+    #         "${{ steps.id.outputs.repo }}" \
+    #         "${{ inputs.slug }}" \
+    #         "${{ inputs.email }}" \
+    #         "${{ steps.token.outputs.token || secrets.key }}"

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -352,7 +352,7 @@ jobs:
     with:
       is_bot: ${{ fromJSON(needs.check.outputs.exists) }}
       branch: "predeval/data"
-      artifact: ${{ matrix.site.owner }}-${{ matrix.site.name }}-predeval
+      artifact: ${{ matrix.site.owner }}-${{ matrix.site.name }}-predeval-data
       owner: ${{ matrix.site.owner }}
       name: ${{ matrix.site.name }}
       slug: ${{ inputs.slug }}

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -343,7 +343,8 @@ jobs:
             "${{ steps.id.outputs.repo }}" \
             "${{ inputs.slug }}" \
             "${{ inputs.email }}" \
-            "${{ steps.token.outputs.token || secrets.key }}"
+            "${{ steps.token.outputs.token || secrets.key }}" \
+          && rm -rf data
       - id: check-predevals-branch
         env:
           GH_TOKEN: ${{ github.token }}
@@ -354,8 +355,7 @@ jobs:
             "${{ steps.id.outputs.repo }}" \
             "${{ inputs.slug }}" \
             "${{ inputs.email }}" \
-            "${{ steps.token.outputs.token || secrets.key }}" \
-          && rm -rf "data/"
+            "${{ steps.token.outputs.token || secrets.key }}"
       - id: checkout-predevals-data
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -123,7 +123,6 @@ jobs:
           path: 'repo'
       - id: build-targets
         name: "Generate scores data"
-        if: ${{ steps.id.outputs.build == 'both' || steps.id.outputs.build == 'target' }}
         run: |
           prefix="https://raw.githubusercontent.com/${{ steps.id.outputs.repo }}/refs/heads"
           oracle="${prefix}/oracle-data/oracle-output.csv"
@@ -265,9 +264,9 @@ jobs:
           name: ${{ steps.id.outputs.file }}
           path: 'out/'
   push-data:
-    name: "Push Forecast Data"
+    name: "Push Data"
     runs-on: ubuntu-latest
-    needs: [check, build-forecasts]
+    needs: [check, build-forecasts, build-evals]
     continue-on-error: true
     strategy: 
       matrix: 
@@ -286,7 +285,8 @@ jobs:
           owner="${{ matrix.site.owner }}"
           name="${{ matrix.site.name }}"
           echo "repo=$owner/$name" >> $GITHUB_OUTPUT
-          echo "file=$owner-$name-data" >> $GITHUB_OUTPUT
+          echo "ptc-file=$owner-$name-data" >> $GITHUB_OUTPUT
+          echo "predevals-file=$owner-$name-evals" >> $GITHUB_OUTPUT
       - uses: actions/create-github-app-token@v1
         if: ${{ fromJSON(needs.check.outputs.exists) }}
         id: token
@@ -295,10 +295,10 @@ jobs:
           private-key: ${{ secrets.key }}
           owner: ${{ matrix.site.owner }}
           repositories: ${{ matrix.site.name }}
-      - id: check-branch
+      - id: check-ptc-branch
         env:
           GH_TOKEN: ${{ github.token }}
-        name: "check for gh-pages branch and create if needed"
+        name: "check for ptc/data branch and create if needed"
         run: | 
           bash -x "${{ github.workspace }}/scripts/check-branch.sh" \
             "ptc/data" \
@@ -306,7 +306,7 @@ jobs:
             "${{ inputs.slug }}" \
             "${{ inputs.email }}" \
             "${{ steps.token.outputs.token || secrets.key }}"
-      - id: checkout-pages
+      - id: checkout-ptc-data
         uses: actions/checkout@v4
         with:
           persist-credentials: false
@@ -314,16 +314,50 @@ jobs:
           ref: ptc/data
           path: 'data'
           token: ${{ steps.token.outputs.token || secrets.key }}
-      - id: fetch-artifact
+      - id: ptc-fetch-artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ steps.id.outputs.file }}
-      - id: publish
+          name: ${{ steps.id.outputs.ptc-file }}
+      - id: ptc-publish
         name: "Publish to ptc/data branch"
         run: | 
           ls -larth
           bash -x "${{ github.workspace }}/scripts/pushit.sh" \
             "ptc/data" \
+            "${{ steps.id.outputs.repo }}" \
+            "${{ inputs.slug }}" \
+            "${{ inputs.email }}" \
+            "${{ steps.token.outputs.token || secrets.key }}"
+      - id: check-predevals-branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        name: "check for predevals/data branch and create if needed"
+        run: |
+          bash -x "${{ github.workspace }}/scripts/check-branch.sh" \
+            "predevals/data" \
+            "${{ steps.id.outputs.repo }}" \
+            "${{ inputs.slug }}" \
+            "${{ inputs.email }}" \
+            "${{ steps.token.outputs.token || secrets.key }}" \
+          && rm -rf "data/"
+      - id: checkout-predevals-data
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          repository: ${{ steps.id.outputs.repo }}
+          ref: predevals/data
+          path: 'data'
+          token: ${{ steps.token.outputs.token || secrets.key }}
+      - id: predevals-fetch-artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ steps.id.outputs.predevals-file }}
+      - id: predevals-publish
+        name: "Publish to predevals/data branch"
+        run: | 
+          ls -larth
+          bash -x "${{ github.workspace }}/scripts/pushit.sh" \
+            "predevals/data" \
             "${{ steps.id.outputs.repo }}" \
             "${{ inputs.slug }}" \
             "${{ inputs.email }}" \

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -1,4 +1,7 @@
 name: "Generate Target and Forecast Data"
+defaults:
+  run:
+    shell: bash
 on:
   workflow_call:
     inputs:
@@ -25,9 +28,6 @@ jobs:
   check:
     name: "Check Bot Status"
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
     outputs:
       exists: ${{ steps.bot.outputs.bot }}
     steps:
@@ -44,9 +44,6 @@ jobs:
     needs: [check]
     name: "Generate Eval Page Data"
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
     continue-on-error: true
     strategy:
       matrix:
@@ -152,9 +149,6 @@ jobs:
     needs: [check]
     name: "Generate Forecast Page Data"
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
     continue-on-error: true
     strategy:
       matrix:
@@ -279,9 +273,6 @@ jobs:
   push-data:
     name: "Push Data"
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
     needs: [check, build-forecasts, build-evals]
     continue-on-error: true
     strategy: 

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -25,6 +25,9 @@ jobs:
   check:
     name: "Check Bot Status"
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     outputs:
       exists: ${{ steps.bot.outputs.bot }}
     steps:
@@ -37,11 +40,13 @@ jobs:
             bot=true
           fi
           echo "bot=$bot" >> "$GITHUB_OUTPUT"
-        shell: bash
   build-evals:
     needs: [check]
     name: "Generate Eval Page Data"
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     continue-on-error: true
     strategy:
       matrix:
@@ -78,34 +83,32 @@ jobs:
             site-config.yml
       - id: check-configs
         name: "Check if we need to build data"
-        shell: "bash"
         run: |
           if [[ ! -f predeval-config.yml ]]; then
             echo "::error title=Missing config (${{ steps.id.outputs.repo }})::No predeval-config.yml file found. Exiting."
             exit 1
           fi
       - id: check-branch
-        name: "check for predevals/data branch"
+        name: "check for predeval/data branch"
         env:
           GH_TOKEN: ${{ steps.token.outputs.token || secrets.key }}
         run: | 
-          exists=$(curl -sSL "https://api.github.com/repos/${{ steps.id.outputs.repo }}/branches" | jq '.[].name | select(. == "predevals/data")')
-          if [[ "$exists" = "predevals/data" ]]; then
+          exists=$(curl -sSL "https://api.github.com/repos/${{ steps.id.outputs.repo }}/branches" | jq '.[].name | select(. == "predeval/data")')
+          if [[ "$exists" = "predeval/data" ]]; then
             fetch=true
           else
             fetch=false
           fi
           echo "fetch=$fetch" >> "$GITHUB_OUTPUT"
-        shell: bash
       - id: checkout-data
         if: ${{ fromJSON(steps.check-branch.outputs.fetch) }}
-        name: "Checkout predevals/data branch"
+        name: "Checkout predeval/data branch"
         uses: actions/checkout@v4
         with:
           token: ${{ steps.token.outputs.token || secrets.key }}
           persist-credentials: false
           repository: ${{ steps.id.outputs.repo }}
-          ref: 'predevals/data'
+          ref: 'predeval/data'
           path: 'out'
       - id: get-repo-name
         name: "Get information about hub"
@@ -141,6 +144,9 @@ jobs:
     needs: [check]
     name: "Generate Forecast Page Data"
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     continue-on-error: true
     strategy:
       matrix:
@@ -188,7 +194,6 @@ jobs:
             site-config.yml
       - id: check-configs
         name: "Check if we need to build data"
-        shell: "bash"
         run: |
           if [[ ! -f predtimechart-config.yml ]]; then
             echo "::error title=Missing config (${{ steps.id.outputs.repo }})::No predtimechart-config.yml file found. Exiting."
@@ -266,6 +271,9 @@ jobs:
   push-data:
     name: "Push Data"
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     needs: [check, build-forecasts, build-evals]
     continue-on-error: true
     strategy: 
@@ -331,10 +339,10 @@ jobs:
       - id: check-predevals-branch
         env:
           GH_TOKEN: ${{ github.token }}
-        name: "check for predevals/data branch and create if needed"
+        name: "check for predeval/data branch and create if needed"
         run: |
           bash -x "${{ github.workspace }}/scripts/check-branch.sh" \
-            "predevals/data" \
+            "predeval/data" \
             "${{ steps.id.outputs.repo }}" \
             "${{ inputs.slug }}" \
             "${{ inputs.email }}" \
@@ -345,7 +353,7 @@ jobs:
         with:
           persist-credentials: false
           repository: ${{ steps.id.outputs.repo }}
-          ref: predevals/data
+          ref: predeval/data
           path: 'data'
           token: ${{ steps.token.outputs.token || secrets.key }}
       - id: predevals-fetch-artifact
@@ -353,11 +361,11 @@ jobs:
         with:
           name: ${{ steps.id.outputs.predevals-file }}
       - id: predevals-publish
-        name: "Publish to predevals/data branch"
+        name: "Publish to predeval/data branch"
         run: | 
           ls -larth
           bash -x "${{ github.workspace }}/scripts/pushit.sh" \
-            "predevals/data" \
+            "predeval/data" \
             "${{ steps.id.outputs.repo }}" \
             "${{ inputs.slug }}" \
             "${{ inputs.email }}" \

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -233,6 +233,7 @@ jobs:
         with:
           python-version: 3.12
       - id: install-predtimechart-tool
+        if: ${{ fromJSON(steps.status-check.outputs.ok) }}
         name: "Install predtimechart conversion tool"
         run: |
           pip install --upgrade pip

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -69,7 +69,7 @@ jobs:
           pip install --upgrade pip
           pip install git+https://github.com/hubverse-org/hub-dashboard-predtimechart
       - uses: actions/create-github-app-token@v1
-        if: ${{ fromJSON(needs.bot.outputs.exists) }}
+        if: ${{ fromJSON(needs.check.outputs.exists) }}
         id: token
         with:
           app-id: ${{ secrets.id }}
@@ -188,7 +188,7 @@ jobs:
           echo "repo=$owner/$name" >> $GITHUB_OUTPUT
           echo "file=$owner-$name-data" >> $GITHUB_OUTPUT
       - uses: actions/create-github-app-token@v1
-        if: ${{ fromJSON(needs.bot.outputs.exists) }}
+        if: ${{ fromJSON(needs.check.outputs.exists) }}
         id: token
         with:
           app-id: ${{ secrets.id }}

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -22,15 +22,13 @@ on:
         required: true
 
 jobs:
-  build-data:
-    name: "Generate Data"
+  check:
+    name: "Check Bot Status"
     runs-on: ubuntu-latest
-    continue-on-error: true
-    strategy:
-      matrix:
-        site: ${{ fromJSON(inputs.repos) }}
+    outputs:
+      exists: ${{ steps.bot.outputs.bot }}
     steps:
-      - id: is-bot
+      - id: bot
         name: "Check if we are running a bot"
         run: |
           if [[ "${{ secrets.id }}" = "none" ]]; then
@@ -40,6 +38,15 @@ jobs:
           fi
           echo "bot=$bot" >> "$GITHUB_OUTPUT"
         shell: bash
+  build-data:
+    needs: [check]
+    name: "Generate Forecast Page Data"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        site: ${{ fromJSON(inputs.repos) }}
+    steps:
       - id: id
         name: "setup run variables"
         run: |
@@ -62,7 +69,7 @@ jobs:
           pip install --upgrade pip
           pip install git+https://github.com/hubverse-org/hub-dashboard-predtimechart
       - uses: actions/create-github-app-token@v1
-        if: ${{ fromJSON(steps.is-bot.outputs.bot) }}
+        if: ${{ fromJSON(needs.bot.outputs.exists) }}
         id: token
         with:
           app-id: ${{ secrets.id }}
@@ -158,24 +165,14 @@ jobs:
           name: ${{ steps.id.outputs.file }}
           path: 'out/'
   push-data:
-    name: "Push Data"
+    name: "Push Forecast Data"
     runs-on: ubuntu-latest
-    needs: [build-data]
+    needs: [check, build-data]
     continue-on-error: true
     strategy: 
       matrix: 
         site: ${{ fromJSON(inputs.repos) }}
     steps:
-      - id: is-bot
-        name: "Check if we are running a bot"
-        run: |
-          if [[ "${{ secrets.id }}" = "none" ]]; then
-            bot=false
-          else
-            bot=true
-          fi
-          echo "bot=$bot" >> "$GITHUB_OUTPUT"
-        shell: bash
       - id: checkout-this-here-repo-scripts
         uses: actions/checkout@v4
         with:
@@ -191,7 +188,7 @@ jobs:
           echo "repo=$owner/$name" >> $GITHUB_OUTPUT
           echo "file=$owner-$name-data" >> $GITHUB_OUTPUT
       - uses: actions/create-github-app-token@v1
-        if: ${{ fromJSON(steps.is-bot.outputs.bot) }}
+        if: ${{ fromJSON(needs.bot.outputs.exists) }}
         id: token
         with:
           app-id: ${{ secrets.id }}

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -319,13 +319,13 @@ jobs:
           path: 'out/'
   check-forecasts:
     needs: [build-forecasts]
-    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/filter-matrix.yaml@znk/hub-evals
+    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/filter-matrix.yaml@main
     with:
       artifact: "ptc-*"
   push-ptc-data:
     needs: [check, check-forecasts]
     if: ${{ needs.check-forecasts.outputs.process }}
-    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/push-things.yaml@znk/hub-evals
+    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/push-things.yaml@main
     strategy:
       matrix:
         site: ${{ fromJSON(needs.check-forecasts.outputs.matrix) }}
@@ -340,13 +340,13 @@ jobs:
     secrets: inherit
   check-predevals:
     needs: [build-evals]
-    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/filter-matrix.yaml@znk/hub-evals
+    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/filter-matrix.yaml@main
     with:
       artifact: "predevals-*"
   push-predevals-data:
     needs: [check, check-predevals]
     if: ${{ needs.check-predevals.outputs.process }}
-    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/push-things.yaml@znk/hub-evals
+    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/push-things.yaml@main
     strategy:
       matrix:
         site: ${{ fromJSON(needs.check-predevals.outputs.matrix) }}

--- a/.github/workflows/push-things.yaml
+++ b/.github/workflows/push-things.yaml
@@ -64,7 +64,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         name: "check for ${{ inputs.branch }}branch and create if needed"
-        run: | 
+        run: |
           bash -x "${{ github.workspace }}/scripts/check-branch.sh" \
             "${{ inputs.branch }} \
             "${{ steps.id.outputs.repo }}" \

--- a/.github/workflows/push-things.yaml
+++ b/.github/workflows/push-things.yaml
@@ -1,0 +1,95 @@
+name: "Push To Branch"
+defaults:
+  run:
+    shell: bash
+on:
+  workflow_call:
+    inputs:
+      is_bot:
+        required: true
+        type: boolean
+      branch:
+        required: true
+        type: string
+      artifact:
+        required: true
+        type: string
+      owner:
+        required: true
+        type: string
+      name:
+        required: true
+        type: string
+      slug:
+        required: true
+        type: string
+      email:
+        required: true
+        type: string
+    secrets:
+      id:
+        required: true
+      key:
+        required: true
+
+jobs:
+  push-data:
+    name: "Push Data"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - id: checkout-this-here-repo-scripts
+        uses: actions/checkout@v4
+        with:
+          repository: hubverse-org/hub-dashboard-control-room
+          ref: znk/hub-evals
+          persist-credentials: false
+          sparse-checkout: |
+            scripts
+      - id: id
+        name: "setup run variables"
+        run: |
+          owner="${{ inputs.owner }}"
+          name="${{ inputs.name }}"
+          echo "repo=$owner/$name" >> $GITHUB_OUTPUT
+      - uses: actions/create-github-app-token@v1
+        if: ${{ fromJSON(inputs.is_bot) }}
+        id: token
+        with:
+          app-id: ${{ secrets.id }}
+          private-key: ${{ secrets.key }}
+          owner: ${{ inputs.owner }}
+          repositories: ${{ inputs.name }}
+      - id: check-branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        name: "check for ${{ inputs.branch }}branch and create if needed"
+        run: | 
+          bash -x "${{ github.workspace }}/scripts/check-branch.sh" \
+            "${{ inputs.branch }} \
+            "${{ steps.id.outputs.repo }}" \
+            "${{ inputs.slug }}" \
+            "${{ inputs.email }}" \
+            "${{ steps.token.outputs.token || secrets.key }}"
+      - id: checkout-data
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          repository: ${{ steps.id.outputs.repo }}
+          ref: ${{ inputs.branch }}
+          path: 'data'
+          token: ${{ steps.token.outputs.token || secrets.key }}
+      - id: fetch-artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact }}
+      - id: publish
+        name: "Publish to ${{ inputs.branch }} branch"
+        run: | 
+          ls -larth
+          bash -x "${{ github.workspace }}/scripts/pushit.sh" \
+            "${{ inputs.branch }}" \
+            "${{ steps.id.outputs.repo }}" \
+            "${{ inputs.slug }}" \
+            "${{ inputs.email }}" \
+            "${{ steps.token.outputs.token || secrets.key }}"

--- a/.github/workflows/push-things.yaml
+++ b/.github/workflows/push-things.yaml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: hubverse-org/hub-dashboard-control-room
-          ref: znk/hub-evals
+          ref: main
           persist-credentials: false
           sparse-checkout: |
             scripts

--- a/.github/workflows/push-things.yaml
+++ b/.github/workflows/push-things.yaml
@@ -66,7 +66,7 @@ jobs:
         name: "check for ${{ inputs.branch }}branch and create if needed"
         run: |
           bash -x "${{ github.workspace }}/scripts/check-branch.sh" \
-            "${{ inputs.branch }} \
+            "${{ inputs.branch }}" \
             "${{ steps.id.outputs.repo }}" \
             "${{ inputs.slug }}" \
             "${{ inputs.email }}" \

--- a/.github/workflows/rebuild-data.yaml
+++ b/.github/workflows/rebuild-data.yaml
@@ -17,7 +17,7 @@ jobs:
       key: ${{ secrets.PRIVATE_KEY }}
   site:
     needs: [repos]
-    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/generate-data.yaml@main
+    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/generate-data.yaml@znk/hub-evals
     with:
       repos: '${{ needs.repos.outputs.repos }}'
       slug: '${{ needs.repos.outputs.slug }}'

--- a/.github/workflows/rebuild-data.yaml
+++ b/.github/workflows/rebuild-data.yaml
@@ -17,7 +17,7 @@ jobs:
       key: ${{ secrets.PRIVATE_KEY }}
   site:
     needs: [repos]
-    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/generate-data.yaml@znk/hub-evals
+    uses: hubverse-org/hub-dashboard-control-room/.github/workflows/generate-data.yaml@main
     with:
       repos: '${{ needs.repos.outputs.repos }}'
       slug: '${{ needs.repos.outputs.slug }}'

--- a/scripts/pushit.sh
+++ b/scripts/pushit.sh
@@ -25,7 +25,7 @@ case "$branch" in
     dir="data"
     msg="update data"
     amend=false
-    to_copy=("scores", "predeval-options.json")
+    to_copy=("scores" "predeval-options.json")
     ;;
   "*")
     echo "oops"

--- a/scripts/pushit.sh
+++ b/scripts/pushit.sh
@@ -6,15 +6,32 @@ slug="${3:-missing}"
 email="${4:-missing}"
 token="${5:-missing}"
 
-if [[ "$branch" == "gh-pages" ]];then
-  dir="pages"
-  msg="deploy"
-  amend=true
-else
-  dir="data"
-  msg="update data"
-  amend=false
-fi
+
+case "$branch" in
+  "gh-pages")
+    dir="pages"
+    msg="deploy"
+    amend=true
+    touch .nojekyll
+    to_copy=("site/*" ".nojekyll")
+    ;;
+  "ptc/data")
+    dir="data"
+    msg="update data"
+    amend=false
+    to_copy=("forecasts" "targets" "predtimechart-options.json")
+    ;;
+  "predeval/data")
+    dir="data"
+    msg="update data"
+    amend=false
+    to_copy=()
+    ;;
+  "*")
+    echo "oops"
+    ;;
+esac
+
 
 cd "$dir" || (echo "Directory '$dir' not found" && exit 1)
 git config --global user.name "${slug}"
@@ -22,18 +39,16 @@ git config --global user.email "${email}"
 git remote set-url origin "https://${slug}:${token}@github.com/${repo}.git"
 ls
 git status
+
 if [[ "${amend}" == "true" ]]; then
   # remove old data/site contents
   git rm -r "*" || echo "nothing to do"
 fi
-if [[ "$branch" == "gh-pages" ]]; then
-  cp -R ../_site/* .
-  touch .nojekyll
-else 
-  cp -R ../forecasts .
-  cp -R ../targets .
-  cp ../predtimechart-options.json .
-fi
+
+for file in "${to_copy[@]}"; do
+  cp -R "../$file" .
+done
+
 git add .
 if [[ "${amend}" == "true" ]]; then
 git commit --amend -m "$msg"

--- a/scripts/pushit.sh
+++ b/scripts/pushit.sh
@@ -25,7 +25,7 @@ case "$branch" in
     dir="data"
     msg="update data"
     amend=false
-    to_copy=()
+    to_copy=("scores", "predeval-options.json")
     ;;
   "*")
     echo "oops"


### PR DESCRIPTION
I've added steps to generate data for https://github.com/hubverse-org/predeval.

I've also streamlined the workflow a bit to reduce resource usage (that was most of the thrashing) in the following ways: 

1. After checking if the config file exists, the rest of the workflow is conditional on its existence. That is, if the config doesn't exist, then the rest of the workflow does not run and no errors are produced.
2. The matrix jobs are subset to only the parent jobs that produced artifacts, so for example, only the elray1/flusight-hub repo attempts to push evals data. 

I've demonstrated that it works to align with [RFC 2024-12-13](https://github.com/reichlab/decisions/blob/main/decisions/2024-12-13-rfc-hub-dashboard-orchestration.md).

## Template workflow

- repository: https://github.com/zkamvar/evals-test
- [single-repo workflow run](https://github.com/zkamvar/evals-test/actions/runs/12819202314)

## App-based workflow

See the [App-based workflow Run](https://github.com/hubverse-org/hub-dashboard-control-room/actions/runs/12819196142)

Validation that it works on the app side.

1. The Variant Nowcast Hub successfully skips data generation ([skip evals](https://github.com/hubverse-org/hub-dashboard-control-room/actions/runs/12819196142/job/35746383381), and [skip ptc](https://github.com/hubverse-org/hub-dashboard-control-room/actions/runs/12819196142/job/35746384012))
1. [the elray1/flusight-dashboard repo successfully builds the evals data](https://github.com/hubverse-org/hub-dashboard-control-room/actions/runs/12819196142/job/35746382695)
1. [the elray1/flusight-dashboard repos successfully pushes the evals data](https://github.com/hubverse-org/hub-dashboard-control-room/actions/runs/12819196142/job/35746795706)


TODO:

1. (on Evan's side) rename hubverse-org/predeval to hubverse-org/predeval**s**
3. (here) add the s back into these workflows
4. (before merging) reset the branch name in the reusable workflow
