### PR TITLE
[app] only build for known hubs

### DIFF
--- a/.github/workflows/get-installations.yaml
+++ b/.github/workflows/get-installations.yaml
@@ -54,6 +54,7 @@ jobs:
             requirements.txt
             appHelper.py
             getInstallations.py
+            known-hubs.json
       - id: setup-snake
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/get-installations.yaml
+++ b/.github/workflows/get-installations.yaml
@@ -29,8 +29,8 @@ jobs:
   repos:
     name: "Get list of dashboard repositories"
     env:
-      APP_ID: ${{ secrets.id }}
-      PRIVATE_KEY: ${{ secrets.key }}
+      APP_ID: ${{ secrets.id || vars.APP_ID }}
+      PRIVATE_KEY: ${{ secrets.key || vars.APP_KEY }}
     runs-on: ubuntu-latest
     outputs:
       repos: ${{ steps.repos.outputs.repos }}

--- a/.github/workflows/get-installations.yaml
+++ b/.github/workflows/get-installations.yaml
@@ -30,7 +30,7 @@ jobs:
     name: "Get list of dashboard repositories"
     env:
       APP_ID: ${{ secrets.id || vars.APP_ID }}
-      PRIVATE_KEY: ${{ secrets.key || vars.APP_KEY }}
+      PRIVATE_KEY: ${{ secrets.key || secrets.PRIVATE_KEY }}
     runs-on: ubuntu-latest
     outputs:
       repos: ${{ steps.repos.outputs.repos }}

--- a/appHelper.py
+++ b/appHelper.py
@@ -81,9 +81,10 @@ def is_known(repo, known):
     print(f"Trying out {repo}")
     if known is None:
         return(True)
-    mebby = set([repo]) & known
-    print(f"Do I know {mebby}? {len(mebby) > 0}")
-    return(len(mebby) > 0)
+    mebby = len(set([repo]) & known) > 0
+    if mebby is False:
+        print(f"::note::Registered but unknown: {repo}")
+    return(mebby)
 
 def list_repositories():
     '''

--- a/appHelper.py
+++ b/appHelper.py
@@ -17,7 +17,6 @@ def get_known():
     with open("known-hubs.json", "r") as f:
         known = json.load(f)
     hubs = set(["/".join(list(x.values())) for x in known])
-    print(hubs)
     return(hubs)
 
 # generate a random ID to assing the variable
@@ -78,7 +77,6 @@ def get_slug_id():
 
 
 def is_known(repo, known):
-    print(f"Trying out {repo}")
     if known is None:
         return(True)
     mebby = len(set([repo]) & known) > 0

--- a/appHelper.py
+++ b/appHelper.py
@@ -16,7 +16,9 @@ def get_known():
     print("I know some hubs")
     with open("known-hubs.json", "r") as f:
         known = json.load(f)
-    return(set(["/".join(list(x.values())) for x in known]))
+    hubs = set(["/".join(list(x.values())) for x in known])
+    print(hubs)
+    return(hubs)
 
 # generate a random ID to assing the variable
 def id_generator(size=6, chars=string.ascii_uppercase + string.digits):
@@ -76,6 +78,7 @@ def get_slug_id():
 
 
 def is_known(repo, known):
+    print(f"Trying out {repo}")
     if known is None:
         return(True)
     else:

--- a/appHelper.py
+++ b/appHelper.py
@@ -83,7 +83,7 @@ def is_known(repo, known):
         return(True)
     mebby = len(set([repo]) & known) > 0
     if mebby is False:
-        print(f"::note::Registered but unknown: {repo}")
+        print(f"::notice::Registered but unknown: {repo}")
     return(mebby)
 
 def list_repositories():

--- a/appHelper.py
+++ b/appHelper.py
@@ -79,7 +79,7 @@ def is_known(repo, known):
     if known is None:
         return(True)
     else:
-        return(len(set(repo), known) > 0)
+        return(len(set(repo) & known) > 0)
 
 def list_repositories():
     '''

--- a/appHelper.py
+++ b/appHelper.py
@@ -76,7 +76,7 @@ def get_slug_id():
 
 
 def is_known(repo, known):
-    if is known is None:
+    if known is None:
         return(True)
     else:
         return(len(set(repo), known) > 0)

--- a/appHelper.py
+++ b/appHelper.py
@@ -14,7 +14,7 @@ def get_known():
         print("no known hubs")
         return(None)
     print("I know some hubs")
-    with open("known-hubs.json", r) as f:
+    with open("known-hubs.json", "r") as f:
         known = json.load(f)
     return(set(["/".join(list(x.values())) for x in known]))
 

--- a/appHelper.py
+++ b/appHelper.py
@@ -9,6 +9,15 @@ from github import Auth
 from github import Github
 from github import GithubIntegration
 
+def get_known():
+    if not os.path.isfile("known-hubs.json"):
+        print("no known hubs")
+        return(None)
+    print("I know some hubs")
+    with open("known-hubs.json", r) as f:
+        known = json.load(f)
+    return(set(["/".join(list(x.values())) for x in known]))
+
 # generate a random ID to assing the variable
 def id_generator(size=6, chars=string.ascii_uppercase + string.digits):
     return ''.join(random.choice(chars) for _ in range(size))
@@ -66,6 +75,12 @@ def get_slug_id():
     write_string("id", app_usr.id)
 
 
+def is_known(repo, known):
+    if is known is None:
+        return(True)
+    else:
+        return(len(set(repo), known) > 0)
+
 def list_repositories():
     '''
     Create an output item called "repos" that contains a JSON list of
@@ -82,15 +97,16 @@ def list_repositories():
         repos = json.loads(newbies)
     else:
         print("fetching repositories")
+        known = get_known()
         ghapp = get_app()
         repos = []
         for installation in ghapp["inst"]:
             # get the full names for the repositories
-            repos += [{"owner":x.owner.login, "name":x.name} for x in installation.get_repos()]
+            repos += [{"owner":x.owner.login, "name":x.name} for x in installation.get_repos() if is_known(x.full_name, known)]
     invalid = [
         {"owner":"hubverse-org", "name":"hub-dashboard-control-room"},
         {"owner":"zkamvar", "name":"hub-dashboard-control-room"}
-    ]
+    ] 
     for i in invalid:
         try:
             repos.remove(i)

--- a/appHelper.py
+++ b/appHelper.py
@@ -81,8 +81,9 @@ def is_known(repo, known):
     print(f"Trying out {repo}")
     if known is None:
         return(True)
-    else:
-        return(len(set(repo) & known) > 0)
+    mebby = set([repo]) & known
+    print(f"Do I know {mebby}? {len(mebby) > 0}")
+    return(len(mebby) > 0)
 
 def list_repositories():
     '''

--- a/known-hubs.json
+++ b/known-hubs.json
@@ -1,0 +1,22 @@
+[
+  {
+    "owner": "elray1",
+    "name": "flusight-dashboard"
+  },
+  {
+    "owner": "reichlab",
+    "name": "flusight-dashboard"
+  },
+  {
+    "owner": "reichlab",
+    "name": "variant-nowcast-hub-dashboard"
+  },
+  {
+    "owner": "reichlab",
+    "name": "covidhub-dashboard"
+  },
+  {
+    "owner": "hubverse-org",
+    "name": "hub-dashboard-template"
+  }
+]


### PR DESCRIPTION
The original code I wrote for the app was to fetch new installations automatically, but this is.... a bad idea. Instead, I will fetch installations match them against a known list of repositories that we maintain here. 

I have an example of the run here where it correctly identifies hubs that I have not listed in `known-hubs.json`

https://github.com/hubverse-org/hub-dashboard-control-room/actions/runs/12796480122

```
Notice: Registered but unknown: SiKa9026/dummyHub
Notice: Registered but unknown: SiKa9026/pho-hospitalization-forecast
Notice: Registered but unknown: SiKa9026/hospitalization-forecast
Notice: Registered but unknown: SiKa9026/rvdss-forecast
Notice: Registered but unknown: zkamvar/test-hub-dashboard
Notice: Registered but unknown: zkamvar/test-another-dashboard-template
Notice: Registered but unknown: zkamvar/test-hub-dashboard-no-forecasts
```