### PR TITLE
fix main build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
       name: '${{ matrix.site.name }}'
       slug: '${{ needs.repos.outputs.slug }}'
       email: '${{ needs.repos.outputs.email }}'
-      publish: ${{ inputs.publish }}
+      publish: ${{ inputs.publish || github.event_name != "workflow_dispatch" }}
     secrets:
       id: ${{ vars.APP_ID }}
       key: ${{ secrets.PRIVATE_KEY }}

--- a/.github/workflows/rebuild-site.yaml
+++ b/.github/workflows/rebuild-site.yaml
@@ -30,7 +30,7 @@ jobs:
       name: '${{ matrix.site.name }}'
       slug: '${{ needs.repos.outputs.slug }}'
       email: '${{ needs.repos.outputs.email }}'
-      publish: ${{ inputs.publish }}
+      publish: ${{ inputs.publish || github.event_name != "workflow_dispatch" }}
     secrets:
       id: ${{ vars.APP_ID }}
       key: ${{ secrets.PRIVATE_KEY }}


### PR DESCRIPTION
this conditions the publish key whether or not we are dealing with a workflow dispatch or not. 

Use `inputs.publish`. If that's empty or false, then publish only if we are NOT using a workflow dispatch event (which indicates the `false` is intentional and not an omission)
