### PR TITLE
update cryptography vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2024.8.30
 cffi==1.17.1
 charset-normalizer==3.3.2
-cryptography==43.0.1
+cryptography==44.0.1
 Deprecated==1.2.14
 idna==3.10
 pycparser==2.22


### PR DESCRIPTION
This is based on https://github.com/hubverse-org/hub-dashboard-control-room/security/dependabot/1

Based on the changelog for v44, I don't see anything that should break our current setup: https://cryptography.io/en/latest/changelog/#v44-0-0