### PR TITLE
fix dang GHA logic

### DIFF
--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -144,7 +144,7 @@ jobs:
     steps:
       - uses: actions/create-github-app-token@v1
         id: token
-        if: ${{ needs.check.outputs.exists }}
+        if: ${{ fromJSON(needs.check.outputs.exists) }}
         with:
           app-id: ${{ secrets.id }}
           private-key: ${{ secrets.key }}


### PR DESCRIPTION
GitHub job outputs are encoded as text, so if you pass it directly, it's interpreted as a string 'false' or 'true', which are both "truthy".

the _appropriate_ way to do this is to wrap the variable in `fromJSON()` so that it firsts interprets the string as a JSON object and then returns the parsed value.