### PR TITLE
hotfix: oracle-data -> target-data

### DIFF
--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -193,8 +193,8 @@ jobs:
         run: |
           ls -larth
           mkdir -p out/
-          dashboard="https://raw.githubusercontent.com/${{ env.REPO }}/refs/heads"
-          hub="https://raw.githubusercontent.com/${{ env.HUB }}/refs/heads"
+          dashboard="https://raw.githubusercontent.com/${REPO}/refs/heads"
+          hub="https://raw.githubusercontent.com/${HUB}/refs/heads"
           test="${hub}/main/target-data/oracle-output.csv"
           # Test if the oracle output is in the hub main branch or if its in the
           # dashboard oracle-data branch and use the appropriate one for the tool

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -187,11 +187,14 @@ jobs:
           path: 'repo'
       - id: build-targets
         name: "Generate scores data"
+        env:
+          REPO: ${{ needs.check.outputs.repo }}
+          HUB: ${{ needs.check.outputs.hub }}
         run: |
           ls -larth
           mkdir -p out/
-          dashboard="https://raw.githubusercontent.com/${{ needs.check.outputs.repo }}/refs/heads"
-          hub="https://raw.githubusercontent.com/${{ needs.check.outputs.hub }}/refs/heads"
+          dashboard="https://raw.githubusercontent.com/${{ env.REPO }}/refs/heads"
+          hub="https://raw.githubusercontent.com/${{ env.HUB }}/refs/heads"
           test="${hub}/main/target-data/oracle-output.csv"
           # Test if the oracle output is in the hub main branch or if its in the
           # dashboard oracle-data branch and use the appropriate one for the tool

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -191,7 +191,7 @@ jobs:
           ls -larth
           mkdir -p out/
           prefix="https://raw.githubusercontent.com/${{ needs.check.outputs.repo }}/refs/heads"
-          oracle="${prefix}/target-data/oracle-output.csv"
+          oracle="${prefix}/main/target-data/oracle-output.csv"
           create-predevals-data.R \
           -h repo \
           -c predevals-config.yml \

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -191,7 +191,7 @@ jobs:
           ls -larth
           mkdir -p out/
           prefix="https://raw.githubusercontent.com/${{ needs.check.outputs.repo }}/refs/heads"
-          oracle="${prefix}/oracle-data/oracle-output.csv"
+          oracle="${prefix}/target-data/oracle-output.csv"
           create-predevals-data.R \
           -h repo \
           -c predevals-config.yml \

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -190,8 +190,16 @@ jobs:
         run: |
           ls -larth
           mkdir -p out/
-          prefix="https://raw.githubusercontent.com/${{ needs.check.outputs.repo }}/refs/heads"
-          oracle="${prefix}/main/target-data/oracle-output.csv"
+          dashboard="https://raw.githubusercontent.com/${{ needs.check.outputs.repo }}/refs/heads"
+          hub="https://raw.githubusercontent.com/${{ needs.check.outputs.hub }}/refs/heads"
+          test="${hub}/main/target-data/oracle-output.csv"
+          # Test if the oracle output is in the hub main branch or if its in the
+          # dashboard oracle-data branch and use the appropriate one for the tool
+          if curl --head --silent "$test" > /dev/null 2>&1; then
+            oracle="$test"
+          else
+            oracle="${dashboard}/oracle-data/oracle-output.csv"
+          fi
           create-predevals-data.R \
           -h repo \
           -c predevals-config.yml \


### PR DESCRIPTION
The metrocast dashboard [failed to build eval data](https://github.com/reichlab/metrocast-dashboard/actions/runs/13951253781/job/39051110266) because I accidentally specified oracle output to be in an `oracle-output` directory 🙈 

This fixes that issue.