### PR TITLE
group all dependency updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,17 +7,38 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # group all run-of-the mill updates into a single pull request
+    groups:
+      gha-updates:
+        applies-to: version-updates
+        update-types:
+          - patch
+          - minor
 
   - package-ecosystem: "pip"
     # we (for better or worse) have dumped the python code in the root of the repo
     directory: "/"
     schedule:
       interval: "weekly"
+    # group all run-of-the mill updates into a single pull request
+    groups:
+      py-updates:
+        applies-to: version-updates
+        update-types:
+          - patch
+          - minor
 
   - package-ecosystem: "npm"
     # this is code for the hubDashboard app that we will soon discontinue
     directory: "/app/"
     schedule:
       interval: "weekly"
+    # group all run-of-the mill updates into a single pull request
+    groups:
+      js-updates:
+        applies-to: version-updates
+        update-types:
+          - patch
+          - minor
 
 


### PR DESCRIPTION
Based on a loose understanding of https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#prioritizing-meaningful-updates and wanting to updated ecosystems in one fell swoop, I added grouping to all of the ecosystems so that for each, we receive group updates for minor and patch releases.
