### PR TITLE
prevents data from being built on a schedule

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,6 +51,7 @@ jobs:
       key: ${{ secrets.PRIVATE_KEY }}
   data:
     needs: [repos]
+    if: ${{ github.event_name != 'schedule' }}
     permissions:
       contents: write
     strategy:


### PR DESCRIPTION
At the moment, data are rebuilt and pushed to registered hubs (in https://github.com/hubverse-org/hub-dashboard-control-room/blob/main/known-hubs.json) daily.

This PR changes that so that only websites are updated daily. Eventually, we will get rid of this process. 