### PR TITLE
Add regenerate option for target data

### DIFF
--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -292,8 +292,8 @@ jobs:
       - id: build-targets
         name: "Generate target data"
         env:
-          REGENERATE: ${{ inputs.regenerate }}
-        if: ${{ inputs.build == 'both' || inputs.build == 'target' }}
+          REGENERATE: ${{ toJSON(inputs.regenerate) }}
+        if: ${{ toJSON(inputs.build) == 'both' || toJSON(inputs.build) == 'target' }}
         run: |
           ls -larth
           mkdir -p out/targets/
@@ -311,7 +311,7 @@ jobs:
             out/targets
           fi
       - id: json-lives
-        if: ${{ inputs.build == 'both' || inputs.build == 'forecast' }}
+        if: ${{ toJSON(inputs.build) == 'both' || toJSON(inputs.build) == 'forecast' }}
         name: "Generate forecast data"
         env:
           REGENERATE: ${{ inputs.regenerate }}

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -258,7 +258,7 @@ jobs:
         run: |
           latest=$(gh api -X GET "repos/hubverse-org/hub-dashboard-predtimechart/releases/latest" --jq ".tag_name")
           pip install --upgrade pip
-          pip install "git+https://github.com/hubverse-org/hub-dashboard-predtimechart@main"
+          pip install "git+https://github.com/hubverse-org/hub-dashboard-predtimechart@$latest"
       - id: check-branch
         name: "Validate existence of ptc/data branch"
         env:

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -258,7 +258,7 @@ jobs:
         run: |
           latest=$(gh api -X GET "repos/hubverse-org/hub-dashboard-predtimechart/releases/latest" --jq ".tag_name")
           pip install --upgrade pip
-          pip install "git+https://github.com/hubverse-org/hub-dashboard-predtimechart@$latest"
+          pip install "git+https://github.com/hubverse-org/hub-dashboard-predtimechart@main"
       - id: check-branch
         name: "Validate existence of ptc/data branch"
         env:

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -302,7 +302,7 @@ jobs:
           ptc_generate_target_json_files \
             repo \
             predtimechart-config.yml \
-            out/targets
+            out/targets \
             --regenerate
           else
           ptc_generate_target_json_files \

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -291,15 +291,25 @@ jobs:
           path: 'repo'
       - id: build-targets
         name: "Generate target data"
+        env:
+          REGENERATE: ${{ inputs.regenerate }}
         if: ${{ inputs.build == 'both' || inputs.build == 'target' }}
         run: |
           ls -larth
           mkdir -p out/targets/
           mkdir -p out/forecasts/
+          if [[ "$REGENERATE" == 'true' ]]; then
           ptc_generate_target_json_files \
             repo \
             predtimechart-config.yml \
             out/targets
+            --regenerate
+          else
+          ptc_generate_target_json_files \
+            repo \
+            predtimechart-config.yml \
+            out/targets
+          fi
       - id: json-lives
         if: ${{ inputs.build == 'both' || inputs.build == 'forecast' }}
         name: "Generate forecast data"

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -292,8 +292,8 @@ jobs:
       - id: build-targets
         name: "Generate target data"
         env:
-          REGENERATE: ${{ toJSON(inputs.regenerate) }}
-        if: ${{ toJSON(inputs.build) == 'both' || toJSON(inputs.build) == 'target' }}
+          REGENERATE: ${{ inputs.regenerate }}
+        if: ${{ inputs.build == 'both' || inputs.build == 'target' }}
         run: |
           ls -larth
           mkdir -p out/targets/
@@ -311,7 +311,7 @@ jobs:
             out/targets
           fi
       - id: json-lives
-        if: ${{ toJSON(inputs.build) == 'both' || toJSON(inputs.build) == 'forecast' }}
+        if: ${{ inputs.build == 'both' || inputs.build == 'forecast' }}
         name: "Generate forecast data"
         env:
           REGENERATE: ${{ inputs.regenerate }}


### PR DESCRIPTION
This is a new feature in hub-dashboard-predtimechart, so this should not be merged until the new version is released