### PR TITLE
Update links to docs.hubverse.io

### DIFF
--- a/app/app.yml
+++ b/app/app.yml
@@ -127,7 +127,7 @@ default_permissions:
 name: The hubverse dashboard bot
 
 # The homepage of your GitHub App.
-url: https://hubverse.io
+url: https://docs.hubverse.io
 
 # A description of the GitHub App.
 description: A bot to auto-build dashboards


### PR DESCRIPTION
This PR updates `hubverse.io` URLs to point to `docs.hubverse.io`.

📝 Multiple commits — feel free to **Squash and Merge** to keep history clean.