### PR TITLE
prevent new oracle output from building in flusight

### DIFF
--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -212,7 +212,7 @@ jobs:
           # NOTE: 2025-05-01
           #   remove this once CDC gets official target data
           #   https://github.com/reichlab/flusight-dashboard/issues/16#issuecomment-2843589897
-          if [[ ${REPO} != "cdcepi/FluSight-forecast-hub" && $(curl -o /dev/null --silent -Iw '%{http_code}' "$test") == 200 ]]; then
+          if [[ ${HUB} != "cdcepi/FluSight-forecast-hub" && $(curl -o /dev/null --silent -Iw '%{http_code}' "$test") == 200 ]]; then
             oracle="$test"
           else
             oracle="${dashboard}/oracle-data/oracle-output.csv"

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -209,7 +209,10 @@ jobs:
           # Test if the oracle output is in the hub main branch or if its in the
           # dashboard oracle-data branch and use the appropriate one for the tool
           # https://matthewsetter.com/check-if-file-is-available-with-curl/
-          if [[ $(curl -o /dev/null --silent -Iw '%{http_code}' "$test") == 200 ]]; then
+          # NOTE: 2025-05-01
+          #   remove this once CDC gets official target data
+          #   https://github.com/reichlab/flusight-dashboard/issues/16#issuecomment-2843589897
+          if [[ ${REPO} != "cdcepi/FluSight-forecast-hub" && $(curl -o /dev/null --silent -Iw '%{http_code}' "$test") == 200 ]]; then
             oracle="$test"
           else
             oracle="${dashboard}/oracle-data/oracle-output.csv"

--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -212,7 +212,7 @@ jobs:
           # NOTE: 2025-05-01
           #   remove this once CDC gets official target data
           #   https://github.com/reichlab/flusight-dashboard/issues/16#issuecomment-2843589897
-          if [[ ${HUB} != "cdcepi/FluSight-forecast-hub" && $(curl -o /dev/null --silent -Iw '%{http_code}' "$test") == 200 ]]; then
+          if [[ ${HUB%/} != "cdcepi/FluSight-forecast-hub" && $(curl -o /dev/null --silent -Iw '%{http_code}' "$test") == 200 ]]; then
             oracle="$test"
           else
             oracle="${dashboard}/oracle-data/oracle-output.csv"


### PR DESCRIPTION
The oracle output that's present in the current flusight dashboard is not current because it accidentally was incorporated yesterday. This PR will prevent this outdated data from being used. 

See https://github.com/reichlab/flusight-dashboard/issues/16#issuecomment-2843589897 for a detailed analysis.

## Background

Previous PRs implementing this catch:

https://github.com/hubverse-org/hub-dashboard-control-room/pull/52
https://github.com/hubverse-org/hub-dashboard-control-room/pull/39

Eventually, this whole clause will go away. We used this because when Evan was building the evaluations dashboard, we did not have a standard for generating oracle output data, so he stuck it in https://github.com/reichlab/flusight-dashboard/tree/oracle-data and uses [rebuild-oracle-data.yml](https://github.com/reichlab/flusight-dashboard/blob/b137e7d4760b9cfb606d634ff4d9d44efdf8efab/.github/workflows/rebuild-oracle-output.yaml) to regenerate it weekly.
