### PR TITLE
Revert "prevent new oracle output from building in flusight (#67)"

### DIFF
--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -209,10 +209,7 @@ jobs:
           # Test if the oracle output is in the hub main branch or if its in the
           # dashboard oracle-data branch and use the appropriate one for the tool
           # https://matthewsetter.com/check-if-file-is-available-with-curl/
-          # NOTE: 2025-05-01
-          #   remove this once CDC gets official target data
-          #   https://github.com/reichlab/flusight-dashboard/issues/16#issuecomment-2843589897
-          if [[ ${HUB%/} != "cdcepi/FluSight-forecast-hub" && $(curl -o /dev/null --silent -Iw '%{http_code}' "$test") == 200 ]]; then
+          if [[ $(curl -o /dev/null --silent -Iw '%{http_code}' "$test") == 200 ]]; then
             oracle="$test"
           else
             oracle="${dashboard}/oracle-data/oracle-output.csv"


### PR DESCRIPTION
This reverts commit 98640dcb132ac3fe3ccca9e3d9f6c9e69097dce2.

In https://github.com/cdcepi/FluSight-forecast-hub/pull/2122 and https://github.com/cdcepi/FluSight-forecast-hub/pull/2124, we got the approval to include the hubverse-formatted data in the hub. 

Before then, we discovered that the hubverse-formatted data already existed in the hub (see #67). Now that the hubvere-formatted data is in the hub and it will be updated, we can revert this catch. 
