### PR TITLE
explicitly pass secrets to re-usable workflows

### DIFF
--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -354,7 +354,9 @@ jobs:
       name: ${{ needs.check.outputs.name }}
       slug: ${{ inputs.slug }}
       email: ${{ inputs.email }}
-    secrets: inherit
+    secrets:
+      id: ${{ secrets.id }}
+      key: ${{ secrets.key }}
   push-eval-data:
     name: "Push Evals to predevals/data branch"
     permissions:
@@ -370,4 +372,6 @@ jobs:
       name: ${{ needs.check.outputs.name }}
       slug: ${{ inputs.slug }}
       email: ${{ inputs.email }}
-    secrets: inherit
+    secrets:
+      id: ${{ secrets.id }}
+      key: ${{ secrets.key }}

--- a/.github/workflows/generate-site.yaml
+++ b/.github/workflows/generate-site.yaml
@@ -125,4 +125,6 @@ jobs:
       name: ${{ needs.build-site.outputs.name }}
       slug: ${{ inputs.slug }}
       email: ${{ inputs.email }}
-    secrets: inherit
+    secrets:
+      id: ${{ secrets.id }}
+      key: ${{ secrets.key }}


### PR DESCRIPTION
The reusable workflows had been working up until this week, but then
suddently we were getting errors that said secrets varaiables were not
being passed.

Reference for secrets and variables from caller workflows:
<https://docs.github.com/en/actions/sharing-automations/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow>

This explicitly passes the two secrets variables instead of using the
[`secrets: inherit`](https://docs.github.com/en/actions/sharing-automations/reusing-workflows#passing-secrets-to-nested-workflows)
keyword.

This will fix #70
