### PR TITLE
fix github workflow syntax

### DIFF
--- a/.github/workflows/generate-data.yaml
+++ b/.github/workflows/generate-data.yaml
@@ -6,19 +6,19 @@ on:
   workflow_call:
     inputs:
       owner:
-        description: 'name of the repository org/owner. Use `${{ github.event.repository.owner.login }}`'
+        description: 'name of the repository org/owner. Use `github.event.repository.owner.login`'
         required: false
         type: string
       name:
-        description: 'name of the repository. Use `${{ github.event.repository.name }}`'
+        description: 'name of the repository. Use `$github.event.repository.name`'
         required: false
         type: string
       slug:
-        description: 'User id. Use `${{ github.event.repository.owner.login }}` '
+        description: 'User id. Use `$github.event.repository.owner.login'
         required: true
         type: string
       email:
-        description: 'github email for pushing. Use `${{ github.event.repository.owner.id }}+${{ github.event.repository.owner.login }}@users.noreply.github.com`'
+        description: 'github email for pushing. Use `$github.event.repository.owner.id+$github.event.repository.owner.login@users.noreply.github.com`'
         required: true
         type: string
       publish:
@@ -46,7 +46,7 @@ on:
     # repositories without workflows).
     #
     # The default is a workflow-generated token, the pattern will be
-    #   id: 'none' and key: ${{ secrets.GITHUB_TOKEN }}
+    #   id: 'none' and key: secrets.GITHUB_TOKEN
     secrets:
       # 'none' (for same-repo builds) or the app ID of a GitHub app (cross-repo builds)
       id:

--- a/.github/workflows/generate-site.yaml
+++ b/.github/workflows/generate-site.yaml
@@ -6,19 +6,19 @@ on:
   workflow_call:
     inputs:
       owner:
-        description: 'name of the repository org/owner. Use `${{ github.event.repository.owner.login }}`'
+        description: 'name of the repository org/owner. Use `github.event.repository.owner.login`'
         required: false
         type: string
       name:
-        description: 'name of the repository. Use `${{ github.event.repository.name }}`'
+        description: 'name of the repository. Use `$github.event.repository.name`'
         required: false
         type: string
       slug:
-        description: 'User id. Use `${{ github.event.repository.owner.login }}` '
+        description: 'User id. Use `$github.event.repository.owner.login'
         required: true
         type: string
       email:
-        description: 'github email for pushing. Use `${{ github.event.repository.owner.id }}+${{ github.event.repository.owner.login }}@users.noreply.github.com`'
+        description: 'github email for pushing. Use `$github.event.repository.owner.id+$github.event.repository.owner.login@users.noreply.github.com`'
         required: true
         type: string
       publish:
@@ -36,7 +36,7 @@ on:
     # repositories without workflows).
     #
     # The default is a workflow-generated token, the pattern will be
-    #   id: 'none' and key: ${{ secrets.GITHUB_TOKEN }}
+    #   id: 'none' and key: secrets.GITHUB_TOKEN
     secrets:
       # 'none' (for same-repo builds) or the app ID of a GitHub app (cross-repo builds)
       id:

--- a/.github/workflows/push-things.yaml
+++ b/.github/workflows/push-things.yaml
@@ -6,19 +6,19 @@ on:
   workflow_call:
     inputs:
       owner:
-        description: 'name of the repository org/owner. Use `${{ github.event.repository.owner.login }}`'
+        description: 'name of the repository org/owner. Use `github.event.repository.owner.login`'
         required: true
         type: string
       name:
-        description: 'name of the repository. Use `${{ github.event.repository.name }}`'
+        description: 'name of the repository. Use `$github.event.repository.name`'
         required: true
         type: string
       slug:
-        description: 'User id. Use `${{ github.event.repository.owner.login }}` '
+        description: 'User id. Use `$github.event.repository.owner.login'
         required: true
         type: string
       email:
-        description: 'github email for pushing. Use `${{ github.event.repository.owner.id }}+${{ github.event.repository.owner.login }}@users.noreply.github.com`'
+        description: 'github email for pushing. Use `$github.event.repository.owner.id+$github.event.repository.owner.login@users.noreply.github.com`'
         required: true
         type: string
       # the name of the orphan branch to push to
@@ -34,7 +34,7 @@ on:
         required: true
         type: boolean
     # This workflow is always called from another re-usable workflow, so you
-    # will pass id: ${{ secrets.id }} and key: ${{ secrets.key }}
+    # will pass id: secrets.id and key: secrets.key
     secrets:
       # 'none' (for same-repo builds) or the app ID of a GitHub app (cross-repo builds)
       id:


### PR DESCRIPTION
It turns out that you cannot include Github variable syntax inside of
descriptions, otherwise the workflow is invalid.
