### PR TITLE
remove schedule for app-run workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,8 +16,6 @@ on:
     types:
       - "registration"
       - "all"
-  schedule:
-    - cron: "17 19 * * *"
 
 jobs:
   repos:


### PR DESCRIPTION
Now that the variant nowcast hub builds from a workflow, we can disable weekly runs from the GitHub App. 